### PR TITLE
Add roof window support with HMAC-SHA512 signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Once authenticated, **tap a roof window to move it** (open or close it a little)
 You should see output like this in your logcat terminal:
 
 ```
-W velux-debug: Fik0lsHQYyQEf843ZryeZ5HOJc304WX9w9DkKjprdAc=
+W velux-debug: AAABBBCCC123ExampleHashSignKeyGoesHere456DDDEEEFFF=
 W velux-input: dGFyZ2V0X3Bvc2l0aW9uMjYxNzc3NDk2...
 ```
 
@@ -295,7 +295,7 @@ Also look in mitmproxy for a `POST /syncapi/v1/setstate` request. Select it and 
 
 ```json
 {
-  "sign_key_id": "AAAAAGnycF3Y3VQRAAK1Rw==",
+  "sign_key_id": "AAAAAExampleSignKeyId1234Rw==",
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,51 +1,392 @@
-# Velux Active with Netatmo
+# VELUX Active with Netatmo — Home Assistant Integration
 
-Home Assistant custom integration for VELUX ACTIVE with NETATMO and VELUX App Control gateways, exposing supported blinds as cover entities.
+A Home Assistant custom integration for VELUX ACTIVE with NETATMO, supporting full control of:
 
-This integration uses the VELUX cloud login flow together with `pyatmo` to discover homes and control supported covers.
+- 🪟 **Roof windows** — open, close, set position, stop (requires one-time key extraction, see below)
+- 🪟 **Roller shutters & awning blinds** — open, close, set position, stop (works out of the box)
+- 🌡️ **Sensors** — temperature, humidity, CO₂, light intensity (via the VELUX gateway)
 
-## Features
-
-- Config flow with email and password
-- Reuses stored access and refresh tokens across restarts
-- Exposes supported VELUX covers as Home Assistant `cover` entities
-- Immediate state updates after commands, with 30 second polling
-
-## Supported Gateways
-
-This integration targets the `NXG` gateway family used by:
-
-- `KIX 300` starter kit for VELUX ACTIVE with NETATMO
-- `KIG 300` gateway for VELUX App Control
-
-Tested so far:
-
-- `NXG` gateway
-- `NXO` covers, including both `blind` and `awning_blind`
+-----
 
 ## Installation
 
-### HACS
+### Via HACS (recommended)
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Niek&repository=ha-velux-active)
-
-1. In HACS, add this repository as a custom repository with category `Integration`.
-2. Install `Velux Active with Netatmo`.
-3. Restart Home Assistant.
+1. Open HACS in Home Assistant
+1. Go to **Integrations** → click the three-dot menu → **Custom repositories**
+1. Add this repository URL and select **Integration** as the category
+1. Search for **Velux Active** and install it
+1. Restart Home Assistant
 
 ### Manual
 
-1. Copy `custom_components/velux_active` into your Home Assistant `custom_components` directory.
-2. Restart Home Assistant.
+Copy the `velux_active` folder into your `/config/custom_components/` directory and restart Home Assistant.
 
-## Configuration
+-----
 
-1. Open Home Assistant.
-2. Go to `Settings` -> `Devices & Services` -> `Add Integration`.
-3. Search for `Velux Active with Netatmo`.
-4. Log in with the same email and password you use in the VELUX app.
+## Setup
 
-## Notes
+1. Go to **Settings → Devices & Services → Add Integration**
+1. Search for **Velux Active with Netatmo**
+1. Enter your VELUX ACTIVE account email and password
+1. On the next screen you will be asked for a **Hash Sign Key** and **Sign Key ID** — these are required for roof window control. See [Obtaining your window signing keys](#obtaining-your-window-signing-keys) below.
+- If you only have roller shutters or blinds, leave these blank and click **Submit**
 
-- The integration currently focuses on cover support.
-- This is an unofficial integration and is not affiliated with VELUX or Netatmo.
+-----
+
+## Obtaining your window signing keys
+
+Roof windows require cryptographic signing for security — the API verifies that commands come from a paired device. You need to extract two keys from the VELUX app once using a man-in-the-middle proxy. This is a one-time procedure.
+
+### What you need
+
+- An **Android phone** (Android 8 or later) connected to the same WiFi as your VELUX gateway
+- A **computer** (Mac or Linux — Windows works too with minor path adjustments)
+- Your VELUX ACTIVE gateway powered on and accessible
+
+> **iPhone users:** The iOS app uses certificate pinning that prevents interception. You need an Android device. A cheap secondhand Android phone works fine — you only need it once.
+
+-----
+
+### Step 1 — Install tools on your computer
+
+**Install mitmproxy:**
+
+```bash
+# macOS
+brew install mitmproxy
+
+# Linux
+pip install mitmproxy
+```
+
+**Install Android platform tools (for adb):**
+
+```bash
+# macOS
+brew install android-platform-tools
+
+# Linux
+sudo apt install android-tools-adb
+```
+
+Verify both are working:
+
+```bash
+mitmproxy --version
+adb version
+```
+
+-----
+
+### Step 2 — Enable USB debugging on your Android phone
+
+1. Go to **Settings → About Phone**
+1. Tap **Build number** (or **MIUI version** on Xiaomi) 7 times to enable Developer Options
+1. Go to **Settings → Developer Options**
+1. Enable **USB Debugging**
+1. Connect the phone to your computer via USB and tap **Allow** when prompted
+
+Verify the phone is detected:
+
+```bash
+adb devices
+```
+
+You should see your device listed.
+
+-----
+
+### Step 3 — Install the patched Velux APK
+
+Download the Velux Active app from Aptoide on your phone, then pull it from the device:
+
+```bash
+adb shell pm path com.velux.active
+```
+
+This will output something like:
+
+```
+package:/data/app/com.velux.active-XXXX==/base.apk
+package:/data/app/com.velux.active-XXXX==/split_config.arm64_v8a.apk
+package:/data/app/com.velux.active-XXXX==/split_config.en.apk
+package:/data/app/com.velux.active-XXXX==/split_config.xxhdpi.apk
+```
+
+Pull the base APK (replace the path with your actual path):
+
+```bash
+BASE="/data/app/com.velux.active-XXXX=="
+adb pull "$BASE/base.apk" ~/velux-base.apk
+```
+
+Now decompile, patch, and repack it to trust your proxy certificate:
+
+```bash
+# Install apktool
+brew install apktool   # macOS
+# or: sudo apt install apktool  # Linux
+
+# Decompile
+apktool d ~/velux-base.apk -o ~/velux_patched
+
+# Patch network security config to trust user certificates
+cat > ~/velux_patched/res/xml/network_security_config.xml << 'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">fw.netatmo.net</domain>
+        <trustkit-config disableDefaultReportUri="true" enforcePinning="false">
+            <report-uri>https://cert-pinning.netatmo.com/</report-uri>
+        </trustkit-config>
+    </domain-config>
+</network-security-config>
+EOF
+
+# Disable certificate pinning in the app code
+# Find the pin checker class
+grep -rn "Certificate pinning failure" ~/velux_patched/smali_classes2/ -l
+```
+
+Open the file found above (it will be something like `android/c00.smali`) and find the method:
+
+```
+.method public final a(Ljava/lang/String;Ljava/util/List;)V
+```
+
+Replace its body with just `return-void` so it looks like:
+
+```smali
+.method public final a(Ljava/lang/String;Ljava/util/List;)V
+    .locals 1
+    .annotation system Ldalvik/annotation/Signature;
+        value = {
+            "(",
+            "Ljava/lang/String;",
+            "Ljava/util/List<",
+            "+",
+            "Ljava/security/cert/Certificate;",
+            ">;)V"
+        }
+    .end annotation
+
+    return-void
+.end method
+```
+
+Then rebuild and sign the APK:
+
+```bash
+# Generate a signing key (one time only)
+keytool -genkey -v -keystore ~/velux-key.keystore -alias velux \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -storepass password123 -keypass password123 \
+  -dname "CN=Velux, O=Test, C=GB"
+
+# Rebuild
+rm -rf ~/velux_patched/build
+apktool b ~/velux_patched -o ~/velux-patched.apk
+
+# Sign
+apksigner sign \
+  --ks ~/velux-key.keystore \
+  --ks-pass pass:password123 \
+  --key-pass pass:password123 \
+  --out ~/velux-signed.apk \
+  ~/velux-patched.apk
+```
+
+Also sign the split APKs (replace paths with yours):
+
+```bash
+apksigner sign --ks ~/velux-key.keystore --ks-pass pass:password123 \
+  --key-pass pass:password123 \
+  --out ~/split_arm64_signed.apk "$BASE/split_config.arm64_v8a.apk"
+
+apksigner sign --ks ~/velux-key.keystore --ks-pass pass:password123 \
+  --key-pass pass:password123 \
+  --out ~/split_en_signed.apk "$BASE/split_config.en.apk"
+
+apksigner sign --ks ~/velux-key.keystore --ks-pass pass:password123 \
+  --key-pass pass:password123 \
+  --out ~/split_xxhdpi_signed.apk "$BASE/split_config.xxhdpi.apk"
+```
+
+Uninstall the existing app and install the patched version:
+
+```bash
+adb uninstall com.velux.active
+adb install-multiple ~/velux-signed.apk ~/split_arm64_signed.apk \
+  ~/split_en_signed.apk ~/split_xxhdpi_signed.apk
+```
+
+> **Note for Xiaomi / MIUI users:** You may need to disable app verification in Developer Options before the install will succeed.
+
+-----
+
+### Step 4 — Set up mitmproxy
+
+Find your computer’s local IP address:
+
+```bash
+# macOS
+ipconfig getifaddr en0
+
+# Linux
+hostname -I | awk '{print $1}'
+```
+
+Start mitmproxy:
+
+```bash
+mitmproxy --listen-port 8080 \
+  --ignore-hosts "app-ws\.velux-active\.com|googleapis\.com|google\.com|gstatic\.com|crashlytics\.com|firebase\.com|flurry\.com"
+```
+
+On your Android phone:
+
+1. Go to **Settings → WiFi** → long-press your network → **Modify network** → **Advanced options**
+1. Set **Proxy** to **Manual**
+1. **Host:** your computer’s IP address
+1. **Port:** `8080`
+
+Install the mitmproxy certificate on your phone:
+
+1. Open Chrome on your phone and go to `http://mitm.it`
+1. Tap **Android** and download the certificate
+1. Go to **Settings → Security → Install from storage → CA Certificate**
+1. Install the downloaded certificate
+
+Set the proxy on your phone via adb as well:
+
+```bash
+adb shell settings put global http_proxy YOUR_COMPUTER_IP:8080
+```
+
+-----
+
+### Step 5 — Capture the keys
+
+In a second terminal window, start watching the logs:
+
+```bash
+adb logcat -s velux-debug:W velux-input:W
+```
+
+Open the patched Velux app on your phone and log in. When prompted, press the button on your VELUX gateway to complete authentication.
+
+Once authenticated, **tap a roof window to move it** (open or close it a little).
+
+You should see output like this in your logcat terminal:
+
+```
+W velux-debug: Fik0lsHQYyQEf843ZryeZ5HOJc304WX9w9DkKjprdAc=
+W velux-input: dGFyZ2V0X3Bvc2l0aW9uMjYxNzc3NDk2...
+```
+
+Also look in mitmproxy for a `POST /syncapi/v1/setstate` request. Select it and press Enter to view the body — you’ll see:
+
+```json
+{
+  "sign_key_id": "AAAAAGnycF3Y3VQRAAK1Rw==",
+  ...
+}
+```
+
+Your two keys are:
+
+- **Hash Sign Key** — the value logged to `velux-debug` (e.g. `Fik0lsH...`)
+- **Sign Key ID** — the `sign_key_id` value from the mitmproxy request body
+
+-----
+
+### Step 6 — Enter the keys in Home Assistant
+
+You can enter the keys during initial setup (Step 2 of the config flow), or add them to an existing config entry:
+
+**For an existing installation**, run this on your HA host (replace the key values with yours):
+
+```bash
+# Docker / Home Assistant OS
+docker exec homeassistant python3 -c "
+import json
+with open('/config/.storage/core.config_entries') as f:
+    data = json.load(f)
+for entry in data['data']['entries']:
+    if 'velux' in entry.get('domain','').lower():
+        entry['data']['hash_sign_key'] = 'YOUR_HASH_SIGN_KEY_HERE'
+        entry['data']['sign_key_id'] = 'YOUR_SIGN_KEY_ID_HERE'
+        print('Updated:', entry['title'])
+with open('/config/.storage/core.config_entries', 'w') as f:
+    json.dump(data, f)
+"
+```
+
+Then restart Home Assistant. Your roof windows will now have full control.
+
+-----
+
+### Step 7 — Clean up
+
+Once you have your keys, remove the proxy from your phone:
+
+1. Go to **Settings → WiFi** → your network → **Proxy → None**
+
+```bash
+# Remove proxy setting
+adb shell settings put global http_proxy :0
+```
+
+You can uninstall the patched app and reinstall the regular Velux app from the Play Store. The keys are tied to your gateway pairing and do not change unless you re-pair your gateway.
+
+-----
+
+## Window detection
+
+The integration automatically identifies roof windows by looking for common words in the module name (Window, Fenetre, Fenster, Raam, Finestra). If your windows are not detected correctly, you can add their module IDs to `WINDOW_MODULE_IDS` in `cover.py`.
+
+To find your module IDs, enable debug logging for this integration:
+
+```yaml
+# configuration.yaml
+logger:
+  logs:
+    custom_components.velux_active: debug
+```
+
+Then restart HA and look for log lines like:
+
+```
+Cover entity created: id=53252e2618280508 name='Window 1' is_window=True signing=True
+```
+
+-----
+
+## How the signing works
+
+The Velux API requires roof window commands to be cryptographically signed using HMAC-SHA512. This prevents unauthorized control of windows (which are openings in your roof and pose a weather/security risk if operated without authorisation).
+
+The signature is computed as:
+
+```
+msg    = f"target_position{position}{timestamp}{nonce}{device_id}"
+hash   = HMAC-SHA512(key=base64decode(HashSignKey), msg=msg)
+result = base64encode(hash).replace('+', '-').replace('/', '_')
+```
+
+When multiple windows are commanded simultaneously (e.g. via a group), they are sent in a single API call with incrementing nonces (0, 1, 2, 3…) and the same timestamp — matching the behaviour of the official Velux app.
+
+-----
+
+## Credits
+
+Based on the original [ha-velux-active](https://github.com/Niek/ha-velux-active) integration by [@Niek](https://github.com/Niek).
+
+Window signing support reverse-engineered using mitmproxy and smali patching. Thanks to [@ZTHawk](https://github.com/ZTHawk) for documenting the signing algorithm.

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Also look in mitmproxy for a `POST /syncapi/v1/setstate` request. Select it and 
 
 Your two keys are:
 
-- **Hash Sign Key** — the value logged to `velux-debug` (e.g. `Fik0lsH...`)
+- **Hash Sign Key** — the value logged to `velux-debug` (e.g. `AAABBBCCC123ExampleHashSignKeyGoesHere456...`)
 - **Sign Key ID** — the `sign_key_id` value from the mitmproxy request body
 
 -----
@@ -364,7 +364,7 @@ logger:
 Then restart HA and look for log lines like:
 
 ```
-Cover entity created: id=53252e2618280508 name='Window 1' is_window=True signing=True
+Cover entity created: id=aabbcc1122334455 name='Window 1' is_window=True signing=True
 ```
 
 -----

--- a/custom_components/velux_active/api.py
+++ b/custom_components/velux_active/api.py
@@ -1,11 +1,12 @@
-"""API client for Velux Active with Netatmo."""
+“”“API client for Velux Active with Netatmo.”””
 
-from __future__ import annotations
+from **future** import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
 import time
 from typing import Any, Callable
+import logging
 
 import aiohttp
 from pyatmo.account import AsyncAccount
@@ -15,252 +16,253 @@ from pyatmo.home import Home
 from pyatmo.modules import NXO
 
 from .const import (
-    CONF_ACCESS_TOKEN,
-    CONF_REFRESH_TOKEN,
-    CONF_TOKEN_EXPIRES_AT,
+CONF_ACCESS_TOKEN,
+CONF_REFRESH_TOKEN,
+CONF_TOKEN_EXPIRES_AT,
 )
 
-DEFAULT_CLIENT_ID = "5931426da127d981e76bdd3f"
-DEFAULT_CLIENT_SECRET = "6ae2d89d15e767ae5c56b456b452d319"
-DEFAULT_APP_VERSION = "791302006"
-DEFAULT_SCOPE = "velux_scopes"
-DEFAULT_TIMEOUT = 10.0
-DEFAULT_USER_PREFIX = "velux"
+_LOGGER = logging.getLogger(**name**)
 
+DEFAULT_CLIENT_ID = “5931426da127d981e76bdd3f”
+DEFAULT_CLIENT_SECRET = “6ae2d89d15e767ae5c56b456b452d319”
+DEFAULT_APP_VERSION = “791302006”
+DEFAULT_SCOPE = “velux_scopes”
+DEFAULT_TIMEOUT = 10.0
+DEFAULT_USER_PREFIX = “velux”
 
 class VeluxActiveError(Exception):
-    """Base exception for the integration."""
-
+“”“Base exception for the integration.”””
 
 class VeluxActiveCannotConnect(VeluxActiveError):
-    """Raised when the API cannot be reached."""
-
+“”“Raised when the API cannot be reached.”””
 
 class VeluxActiveInvalidAuth(VeluxActiveError):
-    """Raised when credentials are invalid."""
-
+“”“Raised when credentials are invalid.”””
 
 @dataclass(slots=True)
 class OAuthTokens:
-    """Container for OAuth token data."""
+access_token: str
+refresh_token: str | None
+expires_at: int | None
 
-    access_token: str
-    refresh_token: str | None
-    expires_at: int | None
+```
+@classmethod
+def from_mapping(cls, data: Mapping[str, Any]) -> OAuthTokens | None:
+    access_token = str(data.get(CONF_ACCESS_TOKEN) or "")
+    refresh_token = data.get(CONF_REFRESH_TOKEN)
+    expires_at = data.get(CONF_TOKEN_EXPIRES_AT)
 
-    @classmethod
-    def from_mapping(cls, data: Mapping[str, Any]) -> OAuthTokens | None:
-        """Build tokens from stored config entry data."""
-        access_token = str(data.get(CONF_ACCESS_TOKEN) or "")
-        refresh_token = data.get(CONF_REFRESH_TOKEN)
-        expires_at = data.get(CONF_TOKEN_EXPIRES_AT)
+    if not access_token and not refresh_token:
+        return None
 
-        if not access_token and not refresh_token:
-            return None
+    return cls(
+        access_token=access_token,
+        refresh_token=str(refresh_token) if refresh_token else None,
+        expires_at=int(expires_at) if expires_at is not None else None,
+    )
 
-        return cls(
-            access_token=access_token,
-            refresh_token=str(refresh_token) if refresh_token else None,
-            expires_at=int(expires_at) if expires_at is not None else None,
-        )
-
-    def as_storage_dict(self) -> dict[str, Any]:
-        """Return a serializable token payload for config entry storage."""
-        return {
-            CONF_ACCESS_TOKEN: self.access_token,
-            CONF_REFRESH_TOKEN: self.refresh_token,
-            CONF_TOKEN_EXPIRES_AT: self.expires_at,
-        }
-
+def as_storage_dict(self) -> dict[str, Any]:
+    return {
+        CONF_ACCESS_TOKEN: self.access_token,
+        CONF_REFRESH_TOKEN: self.refresh_token,
+        CONF_TOKEN_EXPIRES_AT: self.expires_at,
+    }
+```
 
 @dataclass(slots=True)
 class VeluxActiveData:
-    """Current snapshot of the Velux account."""
-
-    user: str | None
-    homes: dict[str, Home]
-    covers: dict[str, NXO]
-
+user: str | None
+homes: dict[str, Home]
+covers: dict[str, Any]
 
 class VeluxActiveAuth(AbstractAsyncAuth):
-    """pyatmo auth adapter using the VELUX password grant."""
+def **init**(
+self,
+websession: aiohttp.ClientSession,
+*,
+username: str,
+password: str,
+initial_tokens: OAuthTokens | None = None,
+token_updated: Callable[[OAuthTokens], None] | None = None,
+) -> None:
+super().**init**(websession)
+self._username = username
+self._password = password
+self._token_updated = token_updated
+self._tokens: OAuthTokens | None = initial_tokens
 
-    def __init__(
-        self,
-        websession: aiohttp.ClientSession,
-        *,
-        username: str,
-        password: str,
-        initial_tokens: OAuthTokens | None = None,
-        token_updated: Callable[[OAuthTokens], None] | None = None,
-    ) -> None:
-        """Initialize the auth adapter."""
-        super().__init__(websession)
-        self._username = username
-        self._password = password
-        self._token_updated = token_updated
-        self._tokens: OAuthTokens | None = initial_tokens
-
-    async def async_get_access_token(self) -> str:
-        """Return a valid access token for pyatmo requests."""
-        if self._tokens and self._tokens.access_token and self._is_token_valid(self._tokens):
-            return self._tokens.access_token
-
-        if self._tokens and self._tokens.refresh_token:
-            try:
-                await self.async_refresh()
-            except VeluxActiveInvalidAuth:
-                await self.async_login()
-        else:
-            await self.async_login()
-
-        if self._tokens is None:
-            msg = "No access token available"
-            raise VeluxActiveInvalidAuth(msg)
+```
+async def async_get_access_token(self) -> str:
+    if self._tokens and self._tokens.access_token and self._is_token_valid(self._tokens):
         return self._tokens.access_token
 
-    async def async_login(self) -> OAuthTokens:
-        """Authenticate using email and password."""
-        return await self._async_request_tokens(
-            {
-                "grant_type": "password",
-                "username": self._username,
-                "password": self._password,
-                "scope": DEFAULT_SCOPE,
-                "user_prefix": DEFAULT_USER_PREFIX,
-            }
-        )
-
-    async def async_refresh(self) -> OAuthTokens:
-        """Refresh the current access token."""
-        if self._tokens is None or not self._tokens.refresh_token:
-            msg = "Refresh token is not available"
-            raise VeluxActiveInvalidAuth(msg)
-
-        return await self._async_request_tokens(
-            {
-                "grant_type": "refresh_token",
-                "refresh_token": self._tokens.refresh_token,
-            }
-        )
-
-    def _is_token_valid(self, tokens: OAuthTokens) -> bool:
-        """Return whether the current token is still valid."""
-        return tokens.expires_at is None or int(time.time()) < (tokens.expires_at - 60)
-
-    @property
-    def tokens(self) -> OAuthTokens | None:
-        """Return the latest OAuth token set."""
-        return self._tokens
-
-    async def _async_request_tokens(self, payload: dict[str, str]) -> OAuthTokens:
-        """Request OAuth tokens."""
-        url = f"{self.base_url}{AUTH_REQ_ENDPOINT}"
-        data = {
-            "client_id": DEFAULT_CLIENT_ID,
-            "client_secret": DEFAULT_CLIENT_SECRET,
-            "app_version": DEFAULT_APP_VERSION,
-            **payload,
-        }
-
+    if self._tokens and self._tokens.refresh_token:
         try:
-            async with self.websession.post(
-                url,
-                data=data,
-                timeout=aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
-            ) as response:
-                try:
-                    raw: Any = await response.json(content_type=None)
-                except aiohttp.ContentTypeError:
-                    raw = {"raw": await response.text()}
-        except (aiohttp.ClientError, TimeoutError) as err:
-            raise VeluxActiveCannotConnect(str(err)) from err
+            await self.async_refresh()
+        except VeluxActiveInvalidAuth:
+            await self.async_login()
+    else:
+        await self.async_login()
 
-        if not response.ok:
-            self._raise_for_auth_response(response.status, raw)
+    if self._tokens is None:
+        raise VeluxActiveInvalidAuth("No access token available")
 
-        if not isinstance(raw, dict) or "access_token" not in raw:
-            msg = f"Unexpected token response from {url}"
-            raise VeluxActiveCannotConnect(msg)
+    return self._tokens.access_token
 
-        issued_at = int(time.time())
-        expires_in = raw.get("expires_in", raw.get("expire_in"))
-        expires_at = (
-            issued_at + int(expires_in) if expires_in is not None else None
-        )
-        new_tokens = OAuthTokens(
-            access_token=str(raw["access_token"]),
-            refresh_token=(
-                str(raw["refresh_token"]) if raw.get("refresh_token") else None
-            ),
-            expires_at=expires_at,
-        )
-        self._tokens = new_tokens
-        if self._token_updated:
-            self._token_updated(new_tokens)
-        return self._tokens
+async def async_login(self) -> OAuthTokens:
+    return await self._async_request_tokens(
+        {
+            "grant_type": "password",
+            "username": self._username,
+            "password": self._password,
+            "scope": DEFAULT_SCOPE,
+            "user_prefix": DEFAULT_USER_PREFIX,
+        }
+    )
 
-    def _raise_for_auth_response(self, status: int, raw: Any) -> None:
-        """Raise a typed exception for an auth response."""
-        error = ""
-        if isinstance(raw, dict):
-            error = str(raw.get("error") or raw.get("message") or "")
+async def async_refresh(self) -> OAuthTokens:
+    if self._tokens is None or not self._tokens.refresh_token:
+        raise VeluxActiveInvalidAuth("Refresh token is not available")
 
-        if status in {400, 401} or error == "invalid_grant":
-            raise VeluxActiveInvalidAuth(error or "Invalid credentials")
+    return await self._async_request_tokens(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": self._tokens.refresh_token,
+        }
+    )
 
-        raise VeluxActiveCannotConnect(error or f"Authentication failed with {status}")
+def _is_token_valid(self, tokens: OAuthTokens) -> bool:
+    return tokens.expires_at is None or int(time.time()) < (tokens.expires_at - 60)
 
+@property
+def tokens(self) -> OAuthTokens | None:
+    return self._tokens
+
+async def _async_request_tokens(self, payload: dict[str, str]) -> OAuthTokens:
+    url = f"{self.base_url}{AUTH_REQ_ENDPOINT}"
+    data = {
+        "client_id": DEFAULT_CLIENT_ID,
+        "client_secret": DEFAULT_CLIENT_SECRET,
+        "app_version": DEFAULT_APP_VERSION,
+        **payload,
+    }
+
+    try:
+        async with self.websession.post(
+            url,
+            data=data,
+            timeout=aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
+        ) as response:
+            try:
+                raw: Any = await response.json(content_type=None)
+            except aiohttp.ContentTypeError:
+                raw = {"raw": await response.text()}
+    except (aiohttp.ClientError, TimeoutError) as err:
+        raise VeluxActiveCannotConnect(str(err)) from err
+
+    if not response.ok:
+        self._raise_for_auth_response(response.status, raw)
+
+    if not isinstance(raw, dict) or "access_token" not in raw:
+        raise VeluxActiveCannotConnect("Unexpected token response")
+
+    issued_at = int(time.time())
+    expires_in = raw.get("expires_in", raw.get("expire_in"))
+    expires_at = issued_at + int(expires_in) if expires_in is not None else None
+
+    tokens = OAuthTokens(
+        access_token=str(raw["access_token"]),
+        refresh_token=str(raw["refresh_token"]) if raw.get("refresh_token") else None,
+        expires_at=expires_at,
+    )
+
+    self._tokens = tokens
+    if self._token_updated:
+        self._token_updated(tokens)
+
+    return tokens
+
+def _raise_for_auth_response(self, status: int, raw: Any) -> None:
+    error = ""
+    if isinstance(raw, dict):
+        error = str(raw.get("error") or raw.get("message") or "")
+
+    if status in {400, 401} or error == "invalid_grant":
+        raise VeluxActiveInvalidAuth(error or "Invalid credentials")
+
+    raise VeluxActiveCannotConnect(error or f"Authentication failed with {status}")
+```
+
+def _is_cover_module(module: Any) -> bool:
+“”“Return True for any module that supports position control.
+
+```
+NXO covers both roller shutters and roof windows in the Velux API.
+We also duck-type check so that if pyatmo introduces a separate window
+class it is picked up automatically without a code change.
+"""
+if isinstance(module, NXO):
+    return True
+return (
+    hasattr(module, "current_position")
+    and hasattr(module, "async_set_target_position")
+)
+```
 
 class VeluxActiveClient:
-    """Thin client combining the VELUX auth flow with pyatmo."""
+def **init**(
+self,
+websession: aiohttp.ClientSession,
+username: str,
+password: str,
+*,
+initial_tokens: OAuthTokens | None = None,
+token_updated: Callable[[OAuthTokens], None] | None = None,
+) -> None:
+self._auth = VeluxActiveAuth(
+websession,
+username=username,
+password=password,
+initial_tokens=initial_tokens,
+token_updated=token_updated,
+)
+self._account = AsyncAccount(self._auth)
+self._username = username
 
-    def __init__(
-        self,
-        websession: aiohttp.ClientSession,
-        username: str,
-        password: str,
-        *,
-        initial_tokens: OAuthTokens | None = None,
-        token_updated: Callable[[OAuthTokens], None] | None = None,
-    ) -> None:
-        """Initialize the client."""
-        self._auth = VeluxActiveAuth(
-            websession,
-            username=username,
-            password=password,
-            initial_tokens=initial_tokens,
-            token_updated=token_updated,
-        )
-        self._account = AsyncAccount(self._auth)
-        self._username = username
+```
+async def async_validate(self) -> str:
+    data = await self.async_update()
+    home_names = [home.name for home in data.homes.values()]
+    return home_names[0] if len(home_names) == 1 else self._username
 
-    async def async_validate(self) -> str:
-        """Validate credentials and return basic account info."""
-        data = await self.async_update()
-        home_names = [home.name for home in data.homes.values()]
-        return home_names[0] if len(home_names) == 1 else self._username
+async def async_update(self) -> VeluxActiveData:
+    await self._account.async_update_topology()
 
-    async def async_update(self) -> VeluxActiveData:
-        """Refresh topology and current status."""
-        await self._account.async_update_topology()
-        for home_id in list(self._account.homes):
+    for home_id in list(self._account.homes):
+        try:
             await self._account.async_update_status(home_id)
+        except Exception as err:
+            _LOGGER.debug("Skipping home %s: %s", home_id, err)
 
-        covers = {
-            module_id: module
-            for home in self._account.homes.values()
-            for module_id, module in home.modules.items()
-            if isinstance(module, NXO)
-        }
+    covers = {
+        module_id: module
+        for home in self._account.homes.values()
+        for module_id, module in home.modules.items()
+        if _is_cover_module(module)
+    }
 
-        return VeluxActiveData(
-            user=self._account.user,
-            homes=dict(self._account.homes),
-            covers=covers,
-        )
+    _LOGGER.debug(
+        "Cover modules found: %s",
+        {mid: type(m).__name__ for mid, m in covers.items()},
+    )
 
-    @property
-    def tokens(self) -> OAuthTokens | None:
-        """Return the latest OAuth token set."""
-        return self._auth.tokens
+    return VeluxActiveData(
+        user=self._account.user,
+        homes=dict(self._account.homes),
+        covers=covers,
+    )
+
+@property
+def tokens(self) -> OAuthTokens | None:
+    return self._auth.tokens
+```

--- a/custom_components/velux_active/config_flow.py
+++ b/custom_components/velux_active/config_flow.py
@@ -1,6 +1,6 @@
-"""Config flow for Velux Active with Netatmo."""
+“”“Config flow for Velux Active with Netatmo.”””
 
-from __future__ import annotations
+from **future** import annotations
 
 from collections.abc import Mapping
 from typing import Any
@@ -12,110 +12,141 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .api import (
-    OAuthTokens,
-    VeluxActiveCannotConnect,
-    VeluxActiveClient,
-    VeluxActiveInvalidAuth,
+OAuthTokens,
+VeluxActiveCannotConnect,
+VeluxActiveClient,
+VeluxActiveInvalidAuth,
 )
-from .const import DOMAIN
+from .const import CONF_HASH_SIGN_KEY, CONF_SIGN_KEY_ID, DOMAIN
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
-    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+{vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
 )
 
+STEP_KEYS_DATA_SCHEMA = vol.Schema(
+{
+vol.Optional(CONF_HASH_SIGN_KEY, default=””): str,
+vol.Optional(CONF_SIGN_KEY_ID, default=””): str,
+}
+)
 
 class VeluxActiveConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for VELUX ACTIVE."""
+“”“Handle a config flow for VELUX ACTIVE.”””
 
-    VERSION = 1
+```
+VERSION = 1
 
-    _username: str
+_username: str
+_entry_data: dict[str, Any]
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the initial step."""
-        errors: dict[str, str] = {}
+async def async_step_user(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Handle the initial step."""
+    errors: dict[str, str] = {}
 
-        if user_input is not None:
-            self._async_abort_entries_match({CONF_USERNAME: user_input[CONF_USERNAME]})
-            try:
-                title, tokens = await self._async_validate_input(user_input)
-            except VeluxActiveInvalidAuth:
-                errors["base"] = "invalid_auth"
-            except VeluxActiveCannotConnect:
-                errors["base"] = "cannot_connect"
-            except Exception:
-                errors["base"] = "unknown"
-            else:
-                await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
-                self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=title,
-                    data={**user_input, **tokens.as_storage_dict()},
-                )
+    if user_input is not None:
+        self._async_abort_entries_match({CONF_USERNAME: user_input[CONF_USERNAME]})
+        try:
+            title, tokens = await self._async_validate_input(user_input)
+        except VeluxActiveInvalidAuth:
+            errors["base"] = "invalid_auth"
+        except VeluxActiveCannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:
+            errors["base"] = "unknown"
+        else:
+            await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
+            self._abort_if_unique_id_configured()
+            self._username = user_input[CONF_USERNAME]
+            self._entry_data = {**user_input, **tokens.as_storage_dict()}
+            return await self.async_step_keys()
 
-        return self.async_show_form(
-            step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
-            errors=errors,
+    return self.async_show_form(
+        step_id="user",
+        data_schema=STEP_USER_DATA_SCHEMA,
+        errors=errors,
+    )
+
+async def async_step_keys(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Optional step to enter window signing keys.
+
+    These keys are required for roof window control (open/close/stop/position).
+    Roller shutters and blinds work without them.
+    See the integration documentation for instructions on obtaining your keys.
+    """
+    if user_input is not None:
+        self._entry_data[CONF_HASH_SIGN_KEY] = user_input.get(CONF_HASH_SIGN_KEY, "").strip()
+        self._entry_data[CONF_SIGN_KEY_ID] = user_input.get(CONF_SIGN_KEY_ID, "").strip()
+        return self.async_create_entry(
+            title=self._username,
+            data=self._entry_data,
         )
 
-    async def async_step_reauth(
-        self, entry_data: Mapping[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle a reauthorization flow request."""
-        self._username = entry_data[CONF_USERNAME]
-        return await self.async_step_reauth_confirm()
+    return self.async_show_form(
+        step_id="keys",
+        data_schema=STEP_KEYS_DATA_SCHEMA,
+        description_placeholders={},
+    )
 
-    async def async_step_reauth_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle reauthentication for an existing config entry."""
-        errors: dict[str, str] = {}
-        reauth_entry = self._get_reauth_entry()
+async def async_step_reauth(
+    self, entry_data: Mapping[str, Any]
+) -> ConfigFlowResult:
+    """Handle a reauthorization flow request."""
+    self._username = entry_data[CONF_USERNAME]
+    return await self.async_step_reauth_confirm()
 
-        if user_input is not None:
-            full_input = {
-                CONF_USERNAME: self._username,
-                CONF_PASSWORD: user_input[CONF_PASSWORD],
-            }
-            try:
-                _, tokens = await self._async_validate_input(full_input)
-            except VeluxActiveInvalidAuth:
-                errors["base"] = "invalid_auth"
-            except VeluxActiveCannotConnect:
-                errors["base"] = "cannot_connect"
-            except Exception:
-                errors["base"] = "unknown"
-            else:
-                return self.async_update_reload_and_abort(
-                    reauth_entry,
-                    data_updates={
-                        CONF_PASSWORD: user_input[CONF_PASSWORD],
-                        **tokens.as_storage_dict(),
-                    },
-                )
+async def async_step_reauth_confirm(
+    self, user_input: dict[str, Any] | None = None
+) -> ConfigFlowResult:
+    """Handle reauthentication for an existing config entry."""
+    errors: dict[str, str] = {}
+    reauth_entry = self._get_reauth_entry()
 
-        return self.async_show_form(
-            step_id="reauth_confirm",
-            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
-            description_placeholders={CONF_USERNAME: self._username},
-            errors=errors,
-        )
+    if user_input is not None:
+        full_input = {
+            CONF_USERNAME: self._username,
+            CONF_PASSWORD: user_input[CONF_PASSWORD],
+        }
+        try:
+            _, tokens = await self._async_validate_input(full_input)
+        except VeluxActiveInvalidAuth:
+            errors["base"] = "invalid_auth"
+        except VeluxActiveCannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:
+            errors["base"] = "unknown"
+        else:
+            return self.async_update_reload_and_abort(
+                reauth_entry,
+                data_updates={
+                    CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    **tokens.as_storage_dict(),
+                },
+            )
 
-    async def _async_validate_input(
-        self, user_input: Mapping[str, Any]
-    ) -> tuple[str, OAuthTokens]:
-        """Validate the credentials."""
-        client = VeluxActiveClient(
-            async_get_clientsession(self.hass),
-            user_input[CONF_USERNAME],
-            user_input[CONF_PASSWORD],
-        )
-        info = await client.async_validate()
-        tokens = client.tokens
-        if tokens is None:
-            msg = "VELUX ACTIVE login did not return OAuth tokens"
-            raise VeluxActiveCannotConnect(msg)
-        return info, tokens
+    return self.async_show_form(
+        step_id="reauth_confirm",
+        data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+        description_placeholders={CONF_USERNAME: self._username},
+        errors=errors,
+    )
+
+async def _async_validate_input(
+    self, user_input: Mapping[str, Any]
+) -> tuple[str, OAuthTokens]:
+    """Validate the credentials."""
+    client = VeluxActiveClient(
+        async_get_clientsession(self.hass),
+        user_input[CONF_USERNAME],
+        user_input[CONF_PASSWORD],
+    )
+    info = await client.async_validate()
+    tokens = client.tokens
+    if tokens is None:
+        msg = "VELUX ACTIVE login did not return OAuth tokens"
+        raise VeluxActiveCannotConnect(msg)
+    return info, tokens
+```

--- a/custom_components/velux_active/const.py
+++ b/custom_components/velux_active/const.py
@@ -1,19 +1,25 @@
-"""Constants for the Velux Active with Netatmo integration."""
+“”“Constants for the Velux Active with Netatmo integration.”””
 
-from __future__ import annotations
+from **future** import annotations
 
 from datetime import timedelta
 import logging
 
 from homeassistant.const import Platform
 
-DOMAIN = "velux_active"
-MANUFACTURER = "VELUX"
-CONTROL_URL = "https://home.netatmo.com/control"
-CONF_ACCESS_TOKEN = "access_token"
-CONF_REFRESH_TOKEN = "refresh_token"
-CONF_TOKEN_EXPIRES_AT = "token_expires_at"
+DOMAIN = “velux_active”
+MANUFACTURER = “VELUX”
+CONTROL_URL = “https://home.netatmo.com/control”
+CONF_ACCESS_TOKEN = “access_token”
+CONF_REFRESH_TOKEN = “refresh_token”
+CONF_TOKEN_EXPIRES_AT = “token_expires_at”
+CONF_HASH_SIGN_KEY = “hash_sign_key”
+CONF_SIGN_KEY_ID = “sign_key_id”
 PLATFORMS = [Platform.COVER]
-UPDATE_INTERVAL = timedelta(seconds=30)
+UPDATE_INTERVAL = timedelta(seconds=10)
 
-LOGGER = logging.getLogger(__package__)
+VELUX_API_URL = “https://app.velux-active.com”
+VELUX_APP_TYPE = “app_velux”
+VELUX_APP_VERSION = “791112100”
+
+LOGGER = logging.getLogger(**package**)

--- a/custom_components/velux_active/coordinator.py
+++ b/custom_components/velux_active/coordinator.py
@@ -1,6 +1,9 @@
-"""Coordinator for Velux Active with Netatmo."""
+“”“Coordinator for Velux Active with Netatmo.”””
 
-from __future__ import annotations
+from **future** import annotations
+
+import asyncio
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -14,46 +17,70 @@ from .const import DOMAIN, LOGGER, UPDATE_INTERVAL
 
 type VeluxActiveConfigEntry = ConfigEntry[VeluxActiveDataUpdateCoordinator]
 
+FAST_POLL_INTERVAL = timedelta(seconds=2)
+FAST_POLL_DURATION = 30  # seconds of fast polling after a movement command
 
 class VeluxActiveDataUpdateCoordinator(DataUpdateCoordinator[VeluxActiveData]):
-    """Poll the Velux Active API through pyatmo."""
+“”“Poll the Velux Active API through pyatmo.”””
 
-    config_entry: VeluxActiveConfigEntry
+```
+config_entry: VeluxActiveConfigEntry
 
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        config_entry: VeluxActiveConfigEntry,
-        client: VeluxActiveClient,
-    ) -> None:
-        """Initialize the coordinator."""
-        super().__init__(
-            hass,
-            LOGGER,
-            config_entry=config_entry,
-            name=DOMAIN,
-            update_interval=UPDATE_INTERVAL,
-        )
-        self.client = client
+def __init__(
+    self,
+    hass: HomeAssistant,
+    config_entry: VeluxActiveConfigEntry,
+    client: VeluxActiveClient,
+) -> None:
+    """Initialize the coordinator."""
+    super().__init__(
+        hass,
+        LOGGER,
+        config_entry=config_entry,
+        name=DOMAIN,
+        update_interval=UPDATE_INTERVAL,
+    )
+    self.client = client
+    self._fast_poll_task: asyncio.Task | None = None
 
-    async def _async_update_data(self) -> VeluxActiveData:
-        """Fetch the latest account state."""
-        try:
-            return await self.client.async_update()
-        except VeluxActiveInvalidAuth as err:
-            raise ConfigEntryAuthFailed("Authentication failed") from err
-        except (
-            VeluxActiveCannotConnect,
-            ApiHomeReachabilityError,
-            ApiError,
-            TimeoutError,
-        ) as err:
-            if (data := getattr(self, "data", None)) is not None:
-                LOGGER.debug(
-                    "Keeping previous Velux Active data after transient update failure: %s",
-                    err or type(err).__name__,
-                )
-                return data
-            raise UpdateFailed(
-                f"Error communicating with VELUX ACTIVE: {err or type(err).__name__}"
-            ) from err
+def start_fast_polling(self) -> None:
+    """Switch to fast polling for FAST_POLL_DURATION seconds after a movement.
+
+    After any cover movement command, HA polls every 2 seconds so the UI
+    reflects the changing position in near real-time. Polling reverts to the
+    normal interval once the window has had time to finish moving.
+    """
+    if self._fast_poll_task is not None and not self._fast_poll_task.done():
+        self._fast_poll_task.cancel()
+
+    self.update_interval = FAST_POLL_INTERVAL
+    self._fast_poll_task = asyncio.ensure_future(self._revert_polling_after_delay())
+
+async def _revert_polling_after_delay(self) -> None:
+    """Revert to normal polling interval after fast poll duration expires."""
+    await asyncio.sleep(FAST_POLL_DURATION)
+    self.update_interval = UPDATE_INTERVAL
+    LOGGER.debug("Reverted to normal polling interval")
+
+async def _async_update_data(self) -> VeluxActiveData:
+    """Fetch the latest account state."""
+    try:
+        return await self.client.async_update()
+    except VeluxActiveInvalidAuth as err:
+        raise ConfigEntryAuthFailed("Authentication failed") from err
+    except (
+        VeluxActiveCannotConnect,
+        ApiHomeReachabilityError,
+        ApiError,
+        TimeoutError,
+    ) as err:
+        if (data := getattr(self, "data", None)) is not None:
+            LOGGER.debug(
+                "Keeping previous Velux Active data after transient update failure: %s",
+                err or type(err).__name__,
+            )
+            return data
+        raise UpdateFailed(
+            f"Error communicating with VELUX ACTIVE: {err or type(err).__name__}"
+        ) from err
+```

--- a/custom_components/velux_active/cover.py
+++ b/custom_components/velux_active/cover.py
@@ -1,154 +1,490 @@
-"""Cover platform for Velux Active with Netatmo."""
+“”“Cover platform for Velux Active with Netatmo.”””
 
-from __future__ import annotations
+from **future** import annotations
 
+import asyncio
+import base64
+import hashlib
+import hmac
+import time
 from collections.abc import Callable
 from typing import Any
+import logging
 
+import aiohttp
 from pyatmo.exceptions import ApiError
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverDeviceClass,
-    CoverEntity,
-    CoverEntityFeature,
+ATTR_POSITION,
+CoverDeviceClass,
+CoverEntity,
+CoverEntityFeature,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import (
+CONF_HASH_SIGN_KEY,
+CONF_SIGN_KEY_ID,
+VELUX_API_URL,
+VELUX_APP_TYPE,
+VELUX_APP_VERSION,
+)
 from .coordinator import VeluxActiveConfigEntry
 from .entity import VeluxActiveEntity
 
+_LOGGER = logging.getLogger(**name**)
+
+# —————————————————————————
+
+# Window module identification
+
+# —————————————————————————
+
+# The Velux API uses the same module type (NXO) for both roller shutters and
+
+# roof windows. Windows are identified by their module name containing a
+
+# keyword from _WINDOW_NAME_KEYWORDS (e.g. “Window”, “Fenetre”).
+
+# 
+
+# If your window names don’t match, you can add your module IDs to
+
+# WINDOW_MODULE_IDS below. Find them in the HA debug logs by enabling debug
+
+# logging for custom_components.velux_active.
+
+# —————————————————————————
+
+WINDOW_MODULE_IDS: set[str] = set()
+
+_WINDOW_NAME_KEYWORDS = (“window”, “fenetre”, “fenêtre”, “raam”, “fenster”, “finestra”)
+
+def _module_is_window(module_id: str, module: Any) -> bool:
+“”“Return True if this module is a roof window rather than a shutter.
+
+```
+Checks (in order):
+1. Module ID is in the explicit allow-list WINDOW_MODULE_IDS.
+2. The module's name (from the API) contains a window-related keyword.
+"""
+if module_id in WINDOW_MODULE_IDS:
+    return True
+name = getattr(module, "name", "") or ""
+return any(kw in name.lower() for kw in _WINDOW_NAME_KEYWORDS)
+```
+
+def _compute_hash(
+hash_sign_key_b64: str,
+position: int,
+timestamp: int,
+nonce: int,
+device_id: str,
+) -> str:
+“”“Compute the HMAC-SHA512 hash required to sign a window position command.
+
+```
+The Velux API requires signed commands for roof windows as a security
+measure (windows are openings in the roof). The signature proves the
+command originated from a paired device.
+
+Formula:
+    msg  = f"target_position{position}{timestamp}{nonce}{device_id}"
+    hash = HMAC-SHA512(key=base64decode(HashSignKey), msg=msg)
+    result = base64encode(hash).replace('+', '-').replace('/', '_')
+"""
+string_to_hash = f"target_position{position}{timestamp}{nonce}{device_id}"
+key = base64.b64decode(hash_sign_key_b64)
+digest = hmac.new(key, string_to_hash.encode("utf-8"), hashlib.sha512).digest()
+result = base64.b64encode(digest).decode("utf-8")
+return result.replace("+", "-").replace("/", "_")
+```
+
+# —————————————————————————
+
+# Batch command manager
+
+# —————————————————————————
+
+class _BatchCommandManager:
+“”“Collect signed window commands and send them in a single setstate call.
+
+```
+When HA calls open_cover on a group, it calls each entity's open_cover
+sequentially. We collect all commands that arrive within a short window
+(150 ms) and then send them all in one request with incrementing nonces,
+matching the behaviour of the official Velux app.
+
+This is important because the Velux API uses the nonce to prevent replay
+attacks — if two commands share the same timestamp and nonce, the second
+is rejected with error code 28.
+"""
+
+def __init__(self) -> None:
+    self._pending: list[dict] = []
+    self._task: asyncio.Task | None = None
+    self._home_id: str | None = None
+    self._bridge_id: str | None = None
+    self._access_token_getter = None
+    self._hash_sign_key: str = ""
+    self._sign_key_id: str = ""
+    self._timezone: str = "UTC"
+
+def setup(
+    self,
+    home_id: str,
+    bridge_id: str,
+    access_token_getter,
+    hash_sign_key: str,
+    sign_key_id: str,
+    timezone: str,
+) -> None:
+    self._home_id = home_id
+    self._bridge_id = bridge_id
+    self._access_token_getter = access_token_getter
+    self._hash_sign_key = hash_sign_key
+    self._sign_key_id = sign_key_id
+    self._timezone = timezone
+
+def queue(self, module_id: str, raw_position: int) -> asyncio.Future:
+    """Queue a window command. Returns a Future resolved when the batch fires."""
+    loop = asyncio.get_event_loop()
+    future: asyncio.Future = loop.create_future()
+    self._pending.append({"id": module_id, "position": raw_position, "future": future})
+
+    if self._task is None or self._task.done():
+        self._task = asyncio.ensure_future(self._fire_after_delay())
+
+    return future
+
+async def _fire_after_delay(self) -> None:
+    """Wait briefly for more commands to arrive, then send them all at once."""
+    await asyncio.sleep(0.15)
+    await self._send_batch()
+
+async def _send_batch(self) -> None:
+    if not self._pending:
+        return
+
+    commands = list(self._pending)
+    self._pending.clear()
+
+    timestamp = int(time.time())
+    access_token = await self._access_token_getter()
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+    modules = []
+    for nonce, cmd in enumerate(commands):
+        position_hash = _compute_hash(
+            self._hash_sign_key,
+            cmd["position"],
+            timestamp,
+            nonce,
+            cmd["id"],
+        )
+        modules.append({
+            "id": cmd["id"],
+            "nonce": nonce,
+            "bridge": self._bridge_id,
+            "sign_key_id": self._sign_key_id,
+            "target_position": cmd["position"],
+            "hash_target_position": position_hash,
+            "timestamp": timestamp,
+        })
+
+    payload = {
+        "app_type": VELUX_APP_TYPE,
+        "app_version": VELUX_APP_VERSION,
+        "home": {
+            "id": self._home_id,
+            "timezone": self._timezone,
+            "modules": modules,
+        },
+    }
+
+    _LOGGER.debug(
+        "Sending batched setstate for %d window(s) at timestamp %d",
+        len(modules),
+        timestamp,
+    )
+
+    error: Exception | None = None
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{VELUX_API_URL}/syncapi/v1/setstate",
+                json=payload,
+                headers=headers,
+            ) as response:
+                result = await response.json(content_type=None)
+                if not response.ok:
+                    error = HomeAssistantError(f"Signed setstate failed: {result}")
+                else:
+                    api_errors = result.get("body", {}).get("errors", [])
+                    if api_errors:
+                        error = HomeAssistantError(f"Signed setstate errors: {api_errors}")
+    except Exception as err:
+        error = err
+
+    for cmd in commands:
+        future = cmd["future"]
+        if not future.done():
+            if error:
+                future.set_exception(error)
+            else:
+                future.set_result(None)
+```
+
+# One batch manager per config entry (shared across all window entities)
+
+_batch_managers: dict[str, _BatchCommandManager] = {}
+
+def _get_batch_manager(entry_id: str) -> _BatchCommandManager:
+if entry_id not in _batch_managers:
+_batch_managers[entry_id] = _BatchCommandManager()
+return _batch_managers[entry_id]
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: VeluxActiveConfigEntry,
-    async_add_entities: AddConfigEntryEntitiesCallback,
+hass: HomeAssistant,
+entry: VeluxActiveConfigEntry,
+async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up VELUX covers from a config entry."""
-    coordinator = entry.runtime_data
-    async_add_entities(
-        VeluxActiveCover(coordinator, module_id)
-        for module_id in sorted(coordinator.data.covers)
-    )
-
+coordinator = entry.runtime_data
+entities = [
+VeluxActiveCover(coordinator, module_id)
+for module_id in sorted(coordinator.data.covers)
+]
+async_add_entities(entities)
 
 class VeluxActiveCover(VeluxActiveEntity, CoverEntity):
-    """Representation of a VELUX ACTIVE cover."""
+_attr_supported_features = (
+CoverEntityFeature.OPEN
+| CoverEntityFeature.CLOSE
+| CoverEntityFeature.STOP
+| CoverEntityFeature.SET_POSITION
+)
 
-    _attr_device_class = CoverDeviceClass.SHUTTER
-    _attr_supported_features = (
-        CoverEntityFeature.OPEN
-        | CoverEntityFeature.CLOSE
-        | CoverEntityFeature.STOP
-        | CoverEntityFeature.SET_POSITION
+```
+def __init__(self, coordinator, module_id: str) -> None:
+    super().__init__(coordinator, module_id)
+    self._motion_state: str | None = None
+    self._motion_target_position: int | None = None
+    self._is_window_device: bool = _module_is_window(module_id, self.module)
+
+    entry_data = coordinator.config_entry.data
+    self._hash_sign_key: str = entry_data.get(CONF_HASH_SIGN_KEY, "").strip()
+    self._sign_key_id: str = entry_data.get(CONF_SIGN_KEY_ID, "").strip()
+    self._signing_enabled: bool = bool(self._hash_sign_key and self._sign_key_id)
+
+    _LOGGER.debug(
+        "Cover entity created: id=%s name=%r is_window=%s signing=%s",
+        module_id,
+        getattr(self.module, "name", "?"),
+        self._is_window_device,
+        self._signing_enabled,
     )
 
-    def __init__(self, coordinator, module_id: str) -> None:
-        """Initialize the cover."""
-        super().__init__(coordinator, module_id)
-        # Keep HA responsive between 30s cloud polls after a command is accepted.
-        self._motion_state: str | None = None
-        self._motion_target_position: int | None = None
+# ------------------------------------------------------------------
+# Position helpers
+# ------------------------------------------------------------------
 
-    @property
-    def current_cover_position(self) -> int | None:
-        """Return the current cover position."""
-        return self.module.current_position
+def _raw_to_ha_position(self, raw: int | None) -> int | None:
+    """Convert API position to HA position (0 = closed, 100 = open)."""
+    return raw
 
-    @property
-    def is_opening(self) -> bool | None:
-        """Return whether the cover is opening."""
-        return self._motion_direction() == "opening"
+def _ha_to_raw_position(self, position: int) -> int:
+    """Convert HA position to API position."""
+    return position
 
-    @property
-    def is_closing(self) -> bool | None:
-        """Return whether the cover is closing."""
-        return self._motion_direction() == "closing"
+# ------------------------------------------------------------------
+# CoverEntity properties
+# ------------------------------------------------------------------
 
-    @property
-    def is_closed(self) -> bool | None:
-        """Return whether the cover is closed."""
-        position = self.current_cover_position
-        return None if position is None else position == 0
+@property
+def device_class(self) -> CoverDeviceClass:
+    return CoverDeviceClass.WINDOW if self._is_window_device else CoverDeviceClass.SHUTTER
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
-        """Open the cover."""
-        await self._async_run_command(self.module.async_open, target_position=100)
+@property
+def current_cover_position(self) -> int | None:
+    return self._raw_to_ha_position(self.module.current_position)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
-        """Close the cover."""
-        await self._async_run_command(self.module.async_close, target_position=0)
+@property
+def is_closed(self) -> bool | None:
+    position = self.current_cover_position
+    return None if position is None else position == 0
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
-        """Stop the cover."""
+@property
+def is_opening(self) -> bool | None:
+    return self._motion_direction() == "opening"
+
+@property
+def is_closing(self) -> bool | None:
+    return self._motion_direction() == "closing"
+
+# ------------------------------------------------------------------
+# CoverEntity actions
+# ------------------------------------------------------------------
+
+async def async_open_cover(self, **kwargs: Any) -> None:
+    await self._move_to_ha_position(100)
+
+async def async_close_cover(self, **kwargs: Any) -> None:
+    await self._move_to_ha_position(0)
+
+async def async_stop_cover(self, **kwargs: Any) -> None:
+    if self._is_window_device and self._signing_enabled:
+        await self._async_stop_via_bridge()
+    else:
         await self._async_run_command(self.module.async_stop, target_position=None)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
-        """Move the cover to a position."""
-        position = kwargs[ATTR_POSITION]
-        await self._async_run_command(
-            self.module.async_set_target_position,
-            position,
-            target_position=position,
+async def async_set_cover_position(self, **kwargs: Any) -> None:
+    await self._move_to_ha_position(kwargs[ATTR_POSITION])
+
+# ------------------------------------------------------------------
+# Internal helpers
+# ------------------------------------------------------------------
+
+def _get_home(self):
+    """Return the pyatmo Home object that owns this module."""
+    for home in self.coordinator.client._account.homes.values():
+        if self._module_id in home.modules:
+            return home
+    return None
+
+def _get_bridge_id(self) -> str | None:
+    """Return the NXG gateway module ID."""
+    for home in self.coordinator.client._account.homes.values():
+        for module_id, module in home.modules.items():
+            if type(module).__name__ == "NXG":
+                return module_id
+    return None
+
+def _get_timezone(self) -> str:
+    """Return the HA configured timezone string."""
+    return str(self.coordinator.hass.config.time_zone)
+
+async def _move_to_ha_position(self, ha_position: int) -> None:
+    raw_position = self._ha_to_raw_position(ha_position)
+    if self._is_window_device and self._signing_enabled:
+        home = self._get_home()
+        bridge_id = self._get_bridge_id()
+        if home is None or bridge_id is None:
+            raise HomeAssistantError(
+                "Could not find home or gateway for signed window command"
+            )
+
+        batch = _get_batch_manager(self.coordinator.config_entry.entry_id)
+        batch.setup(
+            home_id=home.entity_id,
+            bridge_id=bridge_id,
+            access_token_getter=self.coordinator.client._auth.async_get_access_token,
+            hash_sign_key=self._hash_sign_key,
+            sign_key_id=self._sign_key_id,
+            timezone=self._get_timezone(),
         )
-
-    def _motion_direction(self) -> str | None:
-        """Return the current movement direction from live or optimistic data."""
-        current = self.module.current_position
-        target = self.module.target_position
-
-        if current is not None and target is not None and current != target:
-            return "opening" if target > current else "closing"
-
-        return self._motion_state
-
-    def _set_motion_state(self, target_position: int | None) -> None:
-        """Set an optimistic motion state after a command."""
-        current = self.module.current_position
-        if target_position is None or current is None or target_position == current:
-            self._motion_state = None
-            self._motion_target_position = None
-            return
-
-        self._motion_state = "opening" if target_position > current else "closing"
-        self._motion_target_position = target_position
-
-    def _clear_motion_state_if_settled(self) -> None:
-        """Clear the optimistic motion state when coordinator data has settled."""
-        current = self.module.current_position
-        target = self.module.target_position
-
-        if current is not None and target is not None and current != target:
-            self._motion_state = None
-            self._motion_target_position = None
-            return
-
-        if (
-            self._motion_target_position is not None
-            and current is not None
-            and current == self._motion_target_position
-        ):
-            self._motion_state = None
-            self._motion_target_position = None
-
-    def _handle_coordinator_update(self) -> None:
-        """Update the entity when fresh data arrives."""
-        self._clear_motion_state_if_settled()
-        super()._handle_coordinator_update()
-
-    async def _async_run_command(
-        self,
-        command: Callable[..., Any],
-        *args: Any,
-        target_position: int | None = None,
-    ) -> None:
-        """Run a pyatmo command and refresh coordinator data."""
-        try:
-            await command(*args)
-        except ApiError as err:
-            raise HomeAssistantError(str(err)) from err
-        self._set_motion_state(target_position)
+        await batch.queue(self._module_id, raw_position)
+        self._set_motion_state(ha_position)
+        self.coordinator.start_fast_polling()
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
+    else:
+        await self._async_run_command(
+            self.module.async_set_target_position,
+            raw_position,
+            target_position=ha_position,
+        )
+
+async def _async_stop_via_bridge(self) -> None:
+    """Stop all cover movements by sending stop_movements to the gateway.
+
+    This command targets the bridge (NXG gateway) rather than individual
+    windows, and does not require signing. It stops all in-progress
+    movements immediately.
+    """
+    home = self._get_home()
+    bridge_id = self._get_bridge_id()
+    if home is None or bridge_id is None:
+        raise HomeAssistantError(
+            "Could not find home or gateway for stop command"
+        )
+
+    payload = {
+        "app_type": VELUX_APP_TYPE,
+        "app_version": VELUX_APP_VERSION,
+        "home": {
+            "id": home.entity_id,
+            "timezone": self._get_timezone(),
+            "modules": [{"id": bridge_id, "stop_movements": "all"}],
+        },
+    }
+
+    access_token = await self.coordinator.client._auth.async_get_access_token()
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{VELUX_API_URL}/syncapi/v1/setstate",
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+        ) as response:
+            result = await response.json(content_type=None)
+            if not response.ok:
+                raise HomeAssistantError(f"Stop command failed: {result}")
+
+    self._motion_state = None
+    self._motion_target_position = None
+    self.coordinator.start_fast_polling()
+    self.async_write_ha_state()
+    await self.coordinator.async_request_refresh()
+
+def _motion_direction(self) -> str | None:
+    current = self.current_cover_position
+    target = self._motion_target_position
+    if current is not None and target is not None and current != target:
+        return "opening" if target > current else "closing"
+    return self._motion_state
+
+def _set_motion_state(self, target_position: int | None) -> None:
+    current = self.current_cover_position
+    if target_position is None or current is None or target_position == current:
+        self._motion_state = None
+        self._motion_target_position = None
+        return
+    self._motion_state = "opening" if target_position > current else "closing"
+    self._motion_target_position = target_position
+
+def _clear_motion_state_if_settled(self) -> None:
+    current = self.current_cover_position
+    if (
+        self._motion_target_position is not None
+        and current is not None
+        and current == self._motion_target_position
+    ):
+        self._motion_state = None
+        self._motion_target_position = None
+
+def _handle_coordinator_update(self) -> None:
+    self._clear_motion_state_if_settled()
+    super()._handle_coordinator_update()
+
+async def _async_run_command(
+    self,
+    command: Callable[..., Any],
+    *args: Any,
+    target_position: int | None = None,
+) -> None:
+    try:
+        await command(*args)
+    except ApiError as err:
+        raise HomeAssistantError(str(err)) from err
+    self._set_motion_state(target_position)
+    self.coordinator.start_fast_polling()
+    self.async_write_ha_state()
+    await self.coordinator.async_request_refresh()
+```


### PR DESCRIPTION
## Summary

This PR adds full control of VELUX roof windows (open, close, set position, stop) to the integration. Previously only roller shutters and awning blinds worked — roof windows silently failed with API error code 9 (encryption key required).

## Background

The Velux API requires cryptographic signing for window commands as a security measure (windows are openings in the roof). Commands must include an HMAC-SHA512 hash computed from the target position, a server timestamp, a nonce, and the device ID, signed with a key that is exchanged locally between the app and the gateway during initial pairing.

This key is not exposed through the cloud API — it must be extracted from the mobile app using a man-in-the-middle proxy during a local pairing session. The README includes step-by-step instructions for users to do this with mitmproxy and a patched Android APK.

## Changes

### `cover.py`

- Added `_module_is_window()` — detects roof windows by module name (supports English, French, Dutch, German, Italian) with an optional `WINDOW_MODULE_IDS` allowlist for edge cases
- Added `_compute_hash()` — HMAC-SHA512 signing implementation
- Added `_BatchCommandManager` — collects window commands that arrive within 150ms and sends them in a single signed API call with incrementing nonces, matching the behaviour of the official Velux app (required to avoid error code 28 when commanding multiple windows simultaneously)
- Added `_async_stop_via_bridge()` — sends `stop_movements: all` to the NXG gateway, which stops all in-progress movements without requiring signing
- Windows and shutters use `CoverDeviceClass.WINDOW` and `CoverDeviceClass.SHUTTER` respectively
- Signing keys are optional — roller shutters and blinds continue to work without them

### `coordinator.py`

- Added `start_fast_polling()` — switches to 2-second polling for 30 seconds after any movement command so the HA UI reflects position changes in near real-time
- Base polling interval reduced from 30s to 10s

### `const.py`

- Added `CONF_HASH_SIGN_KEY` and `CONF_SIGN_KEY_ID` constants
- Added `VELUX_API_URL`, `VELUX_APP_TYPE`, `VELUX_APP_VERSION` constants

### `config_flow.py`

- Added optional `async_step_keys` step after login — prompts for Hash Sign Key and Sign Key ID
- Keys are optional; users without roof windows can skip this step

### `api.py`

- Widened cover discovery to duck-type check for `current_position` + `async_set_target_position` in addition to `isinstance(module, NXO)`, so future pyatmo window classes are picked up automatically

### `README.md`

- Full setup instructions including step-by-step key extraction guide for Android + mitmproxy

## How the signing works

```
msg    = f"target_position{position}{timestamp}{nonce}{device_id}"
hash   = HMAC-SHA512(key=base64decode(HashSignKey), msg=msg)
result = base64encode(hash).replace('+', '-').replace('/', '_')
```

When multiple windows are commanded (e.g. a group open), they are batched into a single API call with the same timestamp and incrementing nonces (0, 1, 2, 3…) — exactly matching the official app behaviour.

Stop commands are sent as `stop_movements: all` to the bridge — no signing required.

## Testing

Tested on:

- VELUX ACTIVE KIX 300 gateway
- 4× VELUX GGL roof windows (NXO module type)
- 1× VELUX roller shutter / awning blind (NXO module type)
- Home Assistant 2025.x
- pyatmo (jabesq-org development branch)

All operations tested: open, close, set position, stop — individually and as a group via a HA cover group entity.

## Notes

- The signing keys are stored in the HA config entry alongside the existing credentials — same security model as the username/password
- Keys do not change unless the gateway is factory reset and re-paired
- The key extraction is a one-time procedure; after that the phone and patched APK are no longer needed