### PR TITLE
Add roof window support with HMAC-SHA512 signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Velux Active with Netatmo
 
-Home Assistant custom integration for VELUX ACTIVE with NETATMO and VELUX App Control gateways, exposing supported blinds as cover entities.
+Home Assistant custom integration for VELUX ACTIVE with NETATMO and VELUX App Control gateways, exposing supported blinds, shutters, and roof windows as cover entities.
 
 This integration uses the VELUX cloud login flow together with `pyatmo` to discover homes and control supported covers.
 
 ## Features
 
 - Config flow with email and password
+- Optional signing-key setup for VELUX roof windows
 - Reuses stored access and refresh tokens across restarts
 - Exposes supported VELUX covers as Home Assistant `cover` entities
 - Immediate state updates after commands, with 30 second polling
@@ -21,7 +22,7 @@ This integration targets the `NXG` gateway family used by:
 Tested so far:
 
 - `NXG` gateway
-- `NXO` covers, including both `blind` and `awning_blind`
+- `NXO` covers, including `blind`, `awning_blind`, and roof windows
 
 ## Installation
 
@@ -44,8 +45,225 @@ Tested so far:
 2. Go to `Settings` -> `Devices & Services` -> `Add Integration`.
 3. Search for `Velux Active with Netatmo`.
 4. Log in with the same email and password you use in the VELUX app.
+5. If you have roof windows, enter the optional signing keys. Blinds and shutters work without them.
+
+## Roof Window Signing Keys
+
+Roof windows require cryptographic signing for security. The VELUX API verifies that commands come from a paired device before it allows a roof window to open or close.
+
+You need to extract two values from the VELUX Android app once:
+
+- **Hash Sign Key**: used to compute the command signature.
+- **Sign Key ID**: sent with signed window commands.
+
+There are two known extraction methods:
+
+- **Method A: mitmproxy** captures `sign_key_id` from the API request and reads `hash_sign_key` from app logs.
+- **Method B: patched APK logcat** logs both values directly from the patched app.
+
+You need an Android phone connected to the same Wi-Fi as your VELUX gateway and a computer with `adb`, `apktool`, and `apksigner`. Install `mitmproxy` too if you want to use Method A.
+
+The iOS app cannot be used for this extraction flow because of certificate pinning.
+
+### Install Tools
+
+```bash
+# macOS
+brew install android-platform-tools apktool
+brew install mitmproxy  # Method A only
+
+# Linux
+sudo apt install android-tools-adb apktool
+pip install mitmproxy  # Method A only
+```
+
+Enable USB debugging on the Android phone, connect it by USB, and verify it is visible:
+
+```bash
+adb devices
+```
+
+### Pull And Patch The APK
+
+Install the VELUX ACTIVE app on the phone, then pull its APK files:
+
+```bash
+mkdir -p ~/velux-apks
+
+adb shell pm path com.velux.active | tr -d '\r' | while IFS= read -r line; do
+  apk="${line#package:}"
+  adb pull "$apk" "$HOME/velux-apks/$(basename "$apk")"
+done
+```
+
+Decompile the base APK:
+
+```bash
+apktool d ~/velux-apks/base.apk -o ~/velux_patched
+```
+
+Choose one of the patch methods below.
+
+### Method A: mitmproxy Patch
+
+Patch the app so it trusts the mitmproxy certificate:
+
+```bash
+cat > ~/velux_patched/res/xml/network_security_config.xml << 'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system"/>
+            <certificates src="user"/>
+        </trust-anchors>
+    </base-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">fw.netatmo.net</domain>
+        <trustkit-config disableDefaultReportUri="true" enforcePinning="false">
+            <report-uri>https://cert-pinning.netatmo.com/</report-uri>
+        </trustkit-config>
+    </domain-config>
+</network-security-config>
+EOF
+```
+
+Disable certificate pinning in the app code:
+
+```bash
+grep -rn "Certificate pinning failure" ~/velux_patched/smali* -l
+```
+
+Open the file found above, find the certificate-check method, and replace its body with `return-void`.
+
+### Method B: Patched APK Logcat
+
+Patch the signing code to log the key values. In the tested APK, this code is in:
+
+```bash
+~/velux_patched/smali/android/br1.smali
+```
+
+The exact filename can change between app versions, so search for the signing mapper if needed:
+
+```bash
+grep -rn "HashMapperKey" ~/velux_patched/smali* | head
+```
+
+Add Android log statements around the signing key values:
+
+- `velux-key-id`: log the Sign Key ID value.
+- `velux-debug`: log the Hash Sign Key value.
+
+After patching, verify the tags exist:
+
+```bash
+grep -rn 'velux-key-id\|velux-debug' ~/velux_patched/smali*
+```
+
+### Rebuild And Install
+
+Generate a signing key, rebuild, and sign the patched base APK:
+
+```bash
+keytool -genkey -v -keystore ~/velux-key.keystore -alias velux \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -storepass password123 -keypass password123 \
+  -dname "CN=Velux, O=Test, C=GB"
+
+rm -rf ~/velux_patched/build
+apktool b ~/velux_patched -o ~/velux-patched.apk
+
+mkdir -p ~/velux-signed
+apksigner sign \
+  --ks ~/velux-key.keystore \
+  --ks-pass pass:password123 \
+  --key-pass pass:password123 \
+  --out ~/velux-signed/base.apk \
+  ~/velux-patched.apk
+```
+
+Sign any split APKs pulled from the device:
+
+```bash
+for apk in ~/velux-apks/split_config*.apk; do
+  [ -e "$apk" ] || continue
+  apksigner sign \
+    --ks ~/velux-key.keystore \
+    --ks-pass pass:password123 \
+    --key-pass pass:password123 \
+    --out "$HOME/velux-signed/$(basename "$apk")" \
+    "$apk"
+done
+```
+
+Install the patched app:
+
+```bash
+adb uninstall com.velux.active
+
+install_apks=(~/velux-signed/base.apk)
+for apk in ~/velux-signed/split_config*.apk; do
+  [ -e "$apk" ] || continue
+  install_apks+=("$apk")
+done
+
+adb install-multiple "${install_apks[@]}"
+```
+
+### Capture Keys With Method A
+
+Start mitmproxy:
+
+```bash
+mitmproxy --listen-port 8080 \
+  --ignore-hosts "app-ws\.velux-active\.com|googleapis\.com|google\.com|gstatic\.com|crashlytics\.com|firebase\.com|flurry\.com"
+```
+
+Set the Android Wi-Fi proxy to your computer on port `8080`, install the certificate from `http://mitm.it`, and optionally set the proxy with adb:
+
+```bash
+adb shell settings put global http_proxy YOUR_COMPUTER_IP:8080
+```
+
+Watch the app logs:
+
+```bash
+adb logcat -s velux-debug:W velux-input:W
+```
+
+Open the patched VELUX app, log in, press the gateway button when prompted, and move a roof window a little.
+
+Use these values:
+
+- **Hash Sign Key**: the `velux-debug` log value.
+- **Sign Key ID**: the `sign_key_id` value in the mitmproxy `POST /syncapi/v1/setstate` request body.
+
+When finished, remove the proxy:
+
+```bash
+adb shell settings put global http_proxy :0
+```
+
+### Capture Keys With Method B
+
+Watch the patched app logs:
+
+```bash
+adb logcat -s velux-key-id:W velux-debug:W
+```
+
+Open the patched VELUX app, log in, press the gateway button when prompted, and move a roof window a little.
+
+Use these values:
+
+- **Hash Sign Key**: the `velux-debug` log value.
+- **Sign Key ID**: the `velux-key-id` log value.
+
+After extracting the keys, you can uninstall the patched app and reinstall the regular VELUX app. The keys are tied to your gateway pairing and do not change unless the gateway is re-paired.
 
 ## Notes
 
 - The integration currently focuses on cover support.
+- Roof window support requires signing keys. Roller shutters and blinds do not.
 - This is an unofficial integration and is not affiliated with VELUX or Netatmo.

--- a/custom_components/velux_active/__init__.py
+++ b/custom_components/velux_active/__init__.py
@@ -38,8 +38,17 @@ async def async_setup_entry(
     )
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
+
+
+async def _async_update_listener(
+    hass: HomeAssistant,
+    entry: VeluxActiveConfigEntry,
+) -> None:
+    """Reload the integration when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(

--- a/custom_components/velux_active/config_flow.py
+++ b/custom_components/velux_active/config_flow.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
 from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -17,10 +18,19 @@ from .api import (
     VeluxActiveClient,
     VeluxActiveInvalidAuth,
 )
-from .const import DOMAIN
+from .const import CONF_HASH_SIGN_KEY, CONF_SIGN_KEY_ID, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+)
+
+STEP_KEYS_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_HASH_SIGN_KEY, default=""): str,
+        vol.Optional(CONF_SIGN_KEY_ID, default=""): str,
+    }
 )
 
 
@@ -29,7 +39,13 @@ class VeluxActiveConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> VeluxActiveOptionsFlow:
+        """Return the options flow handler."""
+        return VeluxActiveOptionsFlow()
+
     _username: str
+    _entry_data: dict[str, Any]
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -46,19 +62,41 @@ class VeluxActiveConfigFlow(ConfigFlow, domain=DOMAIN):
             except VeluxActiveCannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:
+                _LOGGER.exception("Unexpected error during Velux Active config flow")
                 errors["base"] = "unknown"
             else:
                 await self.async_set_unique_id(user_input[CONF_USERNAME].lower())
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=title,
-                    data={**user_input, **tokens.as_storage_dict()},
-                )
+                self._username = title
+                self._entry_data = {**user_input, **tokens.as_storage_dict()}
+                return await self.async_step_keys()
 
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_DATA_SCHEMA,
             errors=errors,
+        )
+
+    async def async_step_keys(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle optional roof-window signing keys."""
+        if user_input is not None:
+            self._entry_data[CONF_HASH_SIGN_KEY] = user_input.get(
+                CONF_HASH_SIGN_KEY, ""
+            ).strip()
+            self._entry_data[CONF_SIGN_KEY_ID] = user_input.get(
+                CONF_SIGN_KEY_ID, ""
+            ).strip()
+            return self.async_create_entry(
+                title=self._username,
+                data=self._entry_data,
+            )
+
+        return self.async_show_form(
+            step_id="keys",
+            data_schema=STEP_KEYS_DATA_SCHEMA,
+            description_placeholders={},
         )
 
     async def async_step_reauth(
@@ -87,6 +125,7 @@ class VeluxActiveConfigFlow(ConfigFlow, domain=DOMAIN):
             except VeluxActiveCannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:
+                _LOGGER.exception("Unexpected error during Velux Active reauth")
                 errors["base"] = "unknown"
             else:
                 return self.async_update_reload_and_abort(
@@ -119,3 +158,38 @@ class VeluxActiveConfigFlow(ConfigFlow, domain=DOMAIN):
             msg = "VELUX ACTIVE login did not return OAuth tokens"
             raise VeluxActiveCannotConnect(msg)
         return info, tokens
+
+
+class VeluxActiveOptionsFlow(OptionsFlow):
+    """Handle options for an existing Velux Active config entry."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the options step."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title="",
+                data={
+                    CONF_HASH_SIGN_KEY: user_input.get(CONF_HASH_SIGN_KEY, "").strip(),
+                    CONF_SIGN_KEY_ID: user_input.get(CONF_SIGN_KEY_ID, "").strip(),
+                },
+            )
+
+        current_key = self.config_entry.options.get(
+            CONF_HASH_SIGN_KEY,
+            self.config_entry.data.get(CONF_HASH_SIGN_KEY, ""),
+        )
+        current_id = self.config_entry.options.get(
+            CONF_SIGN_KEY_ID,
+            self.config_entry.data.get(CONF_SIGN_KEY_ID, ""),
+        )
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_HASH_SIGN_KEY, default=current_key): str,
+                    vol.Optional(CONF_SIGN_KEY_ID, default=current_id): str,
+                }
+            ),
+        )

--- a/custom_components/velux_active/const.py
+++ b/custom_components/velux_active/const.py
@@ -13,7 +13,13 @@ CONTROL_URL = "https://home.netatmo.com/control"
 CONF_ACCESS_TOKEN = "access_token"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_TOKEN_EXPIRES_AT = "token_expires_at"
+CONF_HASH_SIGN_KEY = "hash_sign_key"
+CONF_SIGN_KEY_ID = "sign_key_id"
 PLATFORMS = [Platform.COVER]
 UPDATE_INTERVAL = timedelta(seconds=30)
+
+VELUX_API_URL = "https://app.velux-active.com"
+VELUX_APP_TYPE = "app_velux"
+VELUX_APP_VERSION = "791112100"
 
 LOGGER = logging.getLogger(__package__)

--- a/custom_components/velux_active/cover.py
+++ b/custom_components/velux_active/cover.py
@@ -2,6 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import time
 from collections.abc import Callable
 from typing import Any
 
@@ -15,10 +22,196 @@ from homeassistant.components.cover import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import (
+    CONF_HASH_SIGN_KEY,
+    CONF_SIGN_KEY_ID,
+    VELUX_API_URL,
+    VELUX_APP_TYPE,
+    VELUX_APP_VERSION,
+)
 from .coordinator import VeluxActiveConfigEntry
 from .entity import VeluxActiveEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+WINDOW_MODULE_IDS: set[str] = set()
+_WINDOW_NAME_KEYWORDS = ("window", "fenetre", "fenêtre", "raam", "fenster", "finestra")
+
+
+def _module_is_window(module_id: str, module: Any) -> bool:
+    """Return True if this module is a roof window rather than a shutter."""
+    if str(getattr(module, "velux_type", "") or "").lower() == "window":
+        return True
+    if module_id in WINDOW_MODULE_IDS:
+        return True
+    name = getattr(module, "name", "") or ""
+    return any(keyword in name.lower() for keyword in _WINDOW_NAME_KEYWORDS)
+
+
+def _decode_hash_sign_key(hash_sign_key_b64: str) -> bytes:
+    """Decode a Hash Sign Key in standard or URL-safe Base64 form."""
+    value = hash_sign_key_b64.strip().replace("-", "+").replace("_", "/")
+    value += "=" * (-len(value) % 4)
+    return base64.b64decode(value, validate=True)
+
+
+def _compute_hash(
+    hash_sign_key_b64: str,
+    position: int,
+    timestamp: int,
+    nonce: int,
+    device_id: str,
+) -> str:
+    """Compute the HMAC-SHA512 hash required for a window position command."""
+    string_to_hash = f"target_position{position}{timestamp}{nonce}{device_id}"
+    key = _decode_hash_sign_key(hash_sign_key_b64)
+    digest = hmac.new(key, string_to_hash.encode("utf-8"), hashlib.sha512).digest()
+    result = base64.b64encode(digest).decode("utf-8")
+    return result.replace("+", "-").replace("/", "_")
+
+
+class _BatchCommandManager:
+    """Collect signed window commands and send them in one setstate call."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self._hass = hass
+        self._pending: list[dict[str, Any]] = []
+        self._task: asyncio.Task | None = None
+        self._home_id: str | None = None
+        self._bridge_id: str | None = None
+        self._access_token_getter = None
+        self._hash_sign_key = ""
+        self._sign_key_id = ""
+        self._timezone = "UTC"
+
+    def setup(
+        self,
+        home_id: str,
+        bridge_id: str,
+        access_token_getter,
+        hash_sign_key: str,
+        sign_key_id: str,
+        timezone: str,
+    ) -> None:
+        """Set the API context for the next batch."""
+        self._home_id = home_id
+        self._bridge_id = bridge_id
+        self._access_token_getter = access_token_getter
+        self._hash_sign_key = hash_sign_key
+        self._sign_key_id = sign_key_id
+        self._timezone = timezone
+
+    def queue(self, module_id: str, raw_position: int) -> asyncio.Future:
+        """Queue a window command."""
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future = loop.create_future()
+        self._pending.append({"id": module_id, "position": raw_position, "future": future})
+
+        if self._task is None or self._task.done():
+            self._task = asyncio.ensure_future(self._fire_after_delay())
+
+        return future
+
+    async def _fire_after_delay(self) -> None:
+        """Wait briefly for grouped commands, then send the batch."""
+        await asyncio.sleep(0.5)
+        await self._send_batch()
+
+    async def _send_batch(self) -> None:
+        if not self._pending:
+            return
+
+        seen: dict[str, dict[str, Any]] = {}
+        for command in self._pending:
+            seen[command["id"]] = command
+        commands = list(seen.values())
+        self._pending.clear()
+
+        timestamp = int(time.time())
+        access_token = await self._access_token_getter()
+        modules = []
+        for nonce, command in enumerate(commands):
+            modules.append(
+                {
+                    "id": command["id"],
+                    "nonce": nonce,
+                    "bridge": self._bridge_id,
+                    "sign_key_id": self._sign_key_id,
+                    "target_position": command["position"],
+                    "hash_target_position": _compute_hash(
+                        self._hash_sign_key,
+                        command["position"],
+                        timestamp,
+                        nonce,
+                        command["id"],
+                    ),
+                    "timestamp": timestamp,
+                }
+            )
+
+        payload = {
+            "app_type": VELUX_APP_TYPE,
+            "app_version": VELUX_APP_VERSION,
+            "home": {
+                "id": self._home_id,
+                "timezone": self._timezone,
+                "modules": modules,
+            },
+        }
+
+        error: Exception | None = None
+        try:
+            session = async_get_clientsession(self._hass)
+            async with session.post(
+                f"{VELUX_API_URL}/syncapi/v1/setstate",
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Content-Type": "application/json",
+                },
+            ) as response:
+                text = await response.text()
+                if not text.strip():
+                    error = HomeAssistantError(
+                        f"Empty response from signed setstate (status {response.status})"
+                    )
+                elif not response.ok:
+                    error = HomeAssistantError(f"Signed setstate failed: {text}")
+                else:
+                    result = json.loads(text)
+                    api_errors = result.get("body", {}).get("errors", [])
+                    if api_errors:
+                        _LOGGER.debug(
+                            "Signed setstate API errors: status=%s errors=%s body=%s",
+                            response.status,
+                            api_errors,
+                            text[:1000],
+                        )
+                        error = HomeAssistantError(f"Signed setstate errors: {api_errors}")
+        except Exception as err:
+            _LOGGER.exception("Signed setstate request failed")
+            error = err
+
+        for command in commands:
+            future = command["future"]
+            if not future.done():
+                if error:
+                    future.set_exception(error)
+                else:
+                    future.set_result(None)
+
+
+_batch_managers: dict[str, _BatchCommandManager] = {}
+
+
+def _get_batch_manager(entry_id: str, hass: HomeAssistant) -> _BatchCommandManager:
+    """Return the batch manager for a config entry."""
+    if entry_id not in _batch_managers:
+        _batch_managers[entry_id] = _BatchCommandManager(hass)
+    return _batch_managers[entry_id]
 
 
 async def async_setup_entry(
@@ -37,7 +230,6 @@ async def async_setup_entry(
 class VeluxActiveCover(VeluxActiveEntity, CoverEntity):
     """Representation of a VELUX ACTIVE cover."""
 
-    _attr_device_class = CoverDeviceClass.SHUTTER
     _attr_supported_features = (
         CoverEntityFeature.OPEN
         | CoverEntityFeature.CLOSE
@@ -51,6 +243,33 @@ class VeluxActiveCover(VeluxActiveEntity, CoverEntity):
         # Keep HA responsive between 30s cloud polls after a command is accepted.
         self._motion_state: str | None = None
         self._motion_target_position: int | None = None
+        self._is_window_device = _module_is_window(module_id, self.module)
+
+        entry_data = coordinator.config_entry.data
+        entry_options = coordinator.config_entry.options
+        self._hash_sign_key = entry_options.get(
+            CONF_HASH_SIGN_KEY,
+            entry_data.get(CONF_HASH_SIGN_KEY, ""),
+        ).strip()
+        self._sign_key_id = entry_options.get(
+            CONF_SIGN_KEY_ID,
+            entry_data.get(CONF_SIGN_KEY_ID, ""),
+        ).strip()
+        self._signing_enabled = bool(self._hash_sign_key and self._sign_key_id)
+
+        _LOGGER.debug(
+            "Cover entity created: id=%s name=%r velux_type=%r is_window=%s signing=%s",
+            module_id,
+            getattr(self.module, "name", "?"),
+            getattr(self.module, "velux_type", None),
+            self._is_window_device,
+            self._signing_enabled,
+        )
+
+    @property
+    def device_class(self) -> CoverDeviceClass:
+        """Return the cover device class."""
+        return CoverDeviceClass.WINDOW if self._is_window_device else CoverDeviceClass.SHUTTER
 
     @property
     def current_cover_position(self) -> int | None:
@@ -75,29 +294,126 @@ class VeluxActiveCover(VeluxActiveEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        await self._async_run_command(self.module.async_open, target_position=100)
+        if self._is_window_device and self._signing_enabled:
+            await self._move_to_ha_position(100)
+        else:
+            await self._async_run_command(self.module.async_open, target_position=100)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self._async_run_command(self.module.async_close, target_position=0)
+        if self._is_window_device and self._signing_enabled:
+            await self._move_to_ha_position(0)
+        else:
+            await self._async_run_command(self.module.async_close, target_position=0)
 
     async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        await self._async_run_command(self.module.async_stop, target_position=None)
+        if self._is_window_device and self._signing_enabled:
+            await self._async_stop_via_bridge()
+        else:
+            await self._async_run_command(self.module.async_stop, target_position=None)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a position."""
-        position = kwargs[ATTR_POSITION]
+        await self._move_to_ha_position(kwargs[ATTR_POSITION])
+
+    async def _move_to_ha_position(self, position: int) -> None:
+        """Move the cover to a Home Assistant position."""
+        if self._is_window_device and self._signing_enabled:
+            home = self._get_home()
+            bridge_id = self._get_bridge_id()
+            if home is None or bridge_id is None:
+                raise HomeAssistantError(
+                    "Could not find home or gateway for signed window command"
+                )
+
+            batch = _get_batch_manager(
+                self.coordinator.config_entry.entry_id,
+                self.coordinator.hass,
+            )
+            batch.setup(
+                home_id=home.entity_id,
+                bridge_id=bridge_id,
+                access_token_getter=self.coordinator.client._auth.async_get_access_token,
+                hash_sign_key=self._hash_sign_key,
+                sign_key_id=self._sign_key_id,
+                timezone=str(self.coordinator.hass.config.time_zone),
+            )
+            await batch.queue(self._module_id, position)
+            self._set_motion_state(position)
+            self.async_write_ha_state()
+            await self.coordinator.async_request_refresh()
+            return
+
         await self._async_run_command(
             self.module.async_set_target_position,
             position,
             target_position=position,
         )
 
+    async def _async_stop_via_bridge(self) -> None:
+        """Stop all cover movements by sending stop_movements to the gateway."""
+        home = self._get_home()
+        bridge_id = self._get_bridge_id()
+        if home is None or bridge_id is None:
+            raise HomeAssistantError("Could not find home or gateway for stop command")
+
+        payload = {
+            "app_type": VELUX_APP_TYPE,
+            "app_version": VELUX_APP_VERSION,
+            "home": {
+                "id": home.entity_id,
+                "timezone": str(self.coordinator.hass.config.time_zone),
+                "modules": [{"id": bridge_id, "stop_movements": "all"}],
+            },
+        }
+        access_token = await self.coordinator.client._auth.async_get_access_token()
+        session = async_get_clientsession(self.coordinator.hass)
+        async with session.post(
+            f"{VELUX_API_URL}/syncapi/v1/setstate",
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+        ) as response:
+            text = await response.text()
+            if not text.strip() or not response.ok:
+                raise HomeAssistantError(
+                    f"Stop command failed (status {response.status}): "
+                    f"{text[:200] or 'empty response'}"
+                )
+            result = json.loads(text)
+            api_errors = result.get("body", {}).get("errors", [])
+            if api_errors:
+                raise HomeAssistantError(f"Stop command errors: {api_errors}")
+
+        self._motion_state = None
+        self._motion_target_position = None
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    def _get_home(self):
+        """Return the pyatmo Home object that owns this module."""
+        for home in self.coordinator.client._account.homes.values():
+            if self._module_id in home.modules:
+                return home
+        return None
+
+    def _get_bridge_id(self) -> str | None:
+        """Return the NXG gateway module ID."""
+        for home in self.coordinator.client._account.homes.values():
+            for module_id, module in home.modules.items():
+                if type(module).__name__ == "NXG":
+                    return module_id
+        return None
+
     def _motion_direction(self) -> str | None:
         """Return the current movement direction from live or optimistic data."""
         current = self.module.current_position
-        target = self.module.target_position
+        target = self._motion_target_position
+        if target is None:
+            target = self.module.target_position
 
         if current is not None and target is not None and current != target:
             return "opening" if target > current else "closing"

--- a/custom_components/velux_active/translations/en.json
+++ b/custom_components/velux_active/translations/en.json
@@ -11,6 +11,14 @@
       "unknown": "Unexpected error."
     },
     "step": {
+      "keys": {
+        "data": {
+          "hash_sign_key": "Hash Sign Key",
+          "sign_key_id": "Sign Key ID"
+        },
+        "description": "Enter your window signing keys to enable full control of roof windows. These are optional; roller shutters and blinds work without them. See the integration documentation for instructions on obtaining your keys.",
+        "title": "Window Signing Keys (optional)"
+      },
       "reauth_confirm": {
         "data": {
           "password": "Password"
@@ -25,6 +33,18 @@
         },
         "description": "Log in with your Velux Active with Netatmo app details.",
         "title": "Velux Active with Netatmo"
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "hash_sign_key": "Hash Sign Key",
+          "sign_key_id": "Sign Key ID"
+        },
+        "description": "Update your window signing keys. These are required for roof window control. Leave blank to disable window signing; blinds and shutters still work.",
+        "title": "Update Window Signing Keys"
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR adds signed cover control for VELUX roof windows: open, close, set position, and stop.

Previously the integration only worked reliably for roller shutters and awning blinds. Roof window movement can fail because the VELUX API requires signed commands for windows.

Roller shutters and blinds continue to use the existing pyatmo command path and do not require signing keys.

## Background

The VELUX API requires cryptographic signing for roof-window movement commands as a security measure. Windows are openings in the roof, so the API requires commands to include an HMAC-SHA512 signature proving they came from a paired device.

The signature is computed from the target position, Unix timestamp, nonce, and module ID using the Hash Sign Key exchanged between the mobile app and gateway during pairing.

Those signing values are not exposed through the cloud API. The README documents two Android-based extraction methods:

- mitmproxy: capture `sign_key_id` from the signed API request and read `hash_sign_key` from app logs.
- patched APK logcat: log both `velux-key-id` and `velux-debug` directly from the patched app.

## Why this is robust

- Roof-window detection uses the API `velux_type == "window"` signal when available, but keeps module-ID and translated name-keyword fallbacks for setups where pyatmo or the API does not expose `velux_type`.
- Signing is only used when a cover is detected as a roof window and both signing keys are configured. Everything else stays on the existing pyatmo command path.
- Existing blinds and shutters keep using their current `async_open`, `async_close`, `async_stop`, and `async_set_target_position` behavior.
- Signing keys are optional during setup and can be changed later through the options flow; updating options reloads the integration so entities pick up the new keys.
- Grouped roof-window commands are batched with one timestamp and incrementing nonces, avoiding duplicate nonce failures when Home Assistant sends multiple cover commands together.
- The PR avoids unrelated platform, polling, manifest, ownership, and dependency changes, reducing review surface and regression risk.

## Changes

### `cover.py`

- Add roof-window detection using `velux_type == "window"` with module-ID and name-keyword fallbacks.
- Add `_compute_hash()` for HMAC-SHA512 target-position signatures.
- Add `_BatchCommandManager` to collect grouped roof-window position commands and send them in one signed `setstate` request with incrementing nonces.
- Add signed `/syncapi/v1/setstate` handling for roof-window position commands when signing keys are configured.
- Add bridge-level `stop_movements: all` handling for signed roof-window stop commands.
- Keep the existing unsigned pyatmo path for blinds, shutters, and windows without signing keys.
- Use `CoverDeviceClass.WINDOW` for detected roof windows and `CoverDeviceClass.SHUTTER` otherwise.

### `config_flow.py`

- Add an optional signing-key step after successful login.
- Add an options flow so users can update signing keys without deleting and re-adding the integration.
- Keep signing keys optional so users without roof windows can skip the step.

### `__init__.py`

- Reload the integration when options change so updated signing keys are picked up by cover entities.

### `const.py`

- Add signing-key constants.
- Add VELUX signed `setstate` API constants.

### `translations/en.json`

- Add labels and descriptions for the optional signing-key setup and options flow.

### `README.md`

- Document roof-window signing keys.
- Keep the mitmproxy workflow documented.
- Add patched APK/logcat as an alternative extraction method.

## How signing works

```text
msg    = f"target_position{position}{timestamp}{nonce}{device_id}"
hash   = HMAC-SHA512(key=base64decode(HashSignKey), msg=msg)
result = base64encode(hash).replace('+', '-').replace('/', '_')
```

When multiple roof windows are commanded together, the integration batches them into one signed API call using the same timestamp and incrementing nonces (`0`, `1`, `2`, ...). This matches the pattern used by the official app and avoids nonce collisions.

Stop commands are sent as `stop_movements: all` to the gateway and do not require a per-window signature.

## Scope

This PR intentionally only touches cover support and signing-key configuration.

It does not add lock, switch, sensor, or binary_sensor platforms. It also does not change repository metadata, codeowners, documentation URLs, issue tracker URLs, manifest version, or the `pyatmo` dependency.

## pyatmo note

This PR intentionally leaves the current `pyatmo>=9.3.0,<10.0.0` requirement unchanged.

VELUX can also return schedule type `algo`, which is being handled separately upstream in jabesq-org/pyatmo#564. Once that fix is merged and released, this integration should consider raising the minimum `pyatmo` version to the first release containing it.

## Testing

- `python -m compileall custom_components/velux_active`
- JSON validation for `manifest.json` and `translations/en.json`