### PR TITLE
Add auto-ventilation switch for roof windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ A Home Assistant custom integration for VELUX ACTIVE with NETATMO, supporting:
 
 - **Roof windows** - open, close, set position, stop. Requires one-time gateway pairing for signing keys.
 - **Roller shutters and awning blinds** - open, close, set position, stop. Works out of the box.
+- **Automatic ventilation** - enable or disable the gateway algorithm for roof windows. Works without signing keys.
 
 ---
 
@@ -73,9 +74,21 @@ Advanced/debug signing-key extraction notes are in [`dev/signing-key-extraction.
 After setup, the integration creates cover entities for supported devices:
 
 - **Roof windows**: `cover.window_name` - open, close, set position, stop.
+- **Roof windows**: `switch.window_name_auto_ventilation` - enable or disable automatic ventilation.
 - **Roller shutters / awning blinds**: `cover.blind_name` - open, close, set position, stop.
 
-Roof-window movement requires signing keys. Roller shutters and awning blinds work without signing keys.
+Roof-window movement requires signing keys. Roller shutters, awning blinds, and the auto-ventilation switch work without signing keys.
+
+---
+
+## Automatic Ventilation
+
+For roof windows, the integration exposes an **Auto Ventilation** switch when the VELUX API reports the window algorithm mode.
+
+- On: the VELUX gateway can automatically adjust the window based on its ventilation algorithm.
+- Off: the window only moves in response to manual commands from Home Assistant or the VELUX app.
+
+The switch changes the window `mode` through the VELUX API (an unsigned command) and checks the response for API-level errors.
 
 ---
 

--- a/custom_components/velux_active/__init__.py
+++ b/custom_components/velux_active/__init__.py
@@ -13,7 +13,7 @@ from .coordinator import VeluxActiveDataUpdateCoordinator
 
 type VeluxActiveConfigEntry = ConfigEntry[VeluxActiveDataUpdateCoordinator]
 
-PLATFORMS = [Platform.COVER]
+PLATFORMS = [Platform.COVER, Platform.SWITCH]
 
 
 async def async_setup_entry(

--- a/custom_components/velux_active/cover.py
+++ b/custom_components/velux_active/cover.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -20,18 +19,14 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .batch import BatchCommandError, get_batch_manager
 from .const import (
     CONF_HASH_SIGN_KEY,
     CONF_SIGN_KEY_GATEWAY_ID,
     CONF_SIGN_KEY_ID,
-    VELUX_API_URL,
-    VELUX_APP_TYPE,
-    VELUX_APP_VERSION,
 )
-from .batch import BatchCommandError, get_batch_manager
 from .coordinator import VeluxActiveConfigEntry
 from .entity import VeluxActiveEntity
-from .signing import resolve_bridge_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -171,32 +166,6 @@ class VeluxActiveCover(VeluxActiveEntity, CoverEntity):
     # Internal helpers
     # ------------------------------------------------------------------
 
-    def _get_home(self):
-        """Return the pyatmo Home object that owns this module."""
-        for home in self.coordinator.client._account.homes.values():
-            if self._module_id in home.modules:
-                return home
-        return None
-
-    def _get_bridge_id(self, home) -> str | None:
-        """Return the gateway module ID for this module's owning home.
-
-        Prefer the module's own ``bridge`` link so accounts with multiple
-        gateways route commands to the correct one. Only fall back to a
-        home-wide lookup when that home has exactly one gateway, so we never
-        guess between several.
-        """
-        nxg_ids = [
-            module_id
-            for module_id, module in home.modules.items()
-            if type(module).__name__ == "NXG"
-        ]
-        return resolve_bridge_id(getattr(self.module, "bridge", None), nxg_ids)
-
-    def _get_timezone(self) -> str:
-        """Return the HA configured timezone string."""
-        return str(self.coordinator.hass.config.time_zone)
-
     async def _move_to_ha_position(self, ha_position: int) -> None:
         raw_position = self._ha_to_raw_position(ha_position)
         if self._is_window_device and self._signing_enabled:
@@ -254,37 +223,11 @@ class VeluxActiveCover(VeluxActiveEntity, CoverEntity):
                 "Could not find home or gateway for stop command"
             )
 
-        payload = {
-            "app_type": VELUX_APP_TYPE,
-            "app_version": VELUX_APP_VERSION,
-            "home": {
-                "id": home.entity_id,
-                "timezone": self._get_timezone(),
-                "modules": [{"id": bridge_id, "stop_movements": "all"}],
-            },
-        }
-
-        access_token = await self.coordinator.client._auth.async_get_access_token()
-        session = async_get_clientsession(self.coordinator.hass)
-        async with session.post(
-            f"{VELUX_API_URL}/syncapi/v1/setstate",
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Content-Type": "application/json",
-            },
-        ) as response:
-            text = await response.text()
-            if not text.strip():
-                raise HomeAssistantError(
-                    f"Stop command returned empty response (status {response.status})"
-                )
-            result = json.loads(text)
-            if not response.ok:
-                raise HomeAssistantError(f"Stop command failed: {result}")
-            api_errors = result.get("body", {}).get("errors", [])
-            if api_errors:
-                raise HomeAssistantError(f"Stop command errors: {api_errors}")
+        await self._async_setstate(
+            home,
+            [{"id": bridge_id, "stop_movements": "all"}],
+            action="Stop command",
+        )
 
         self._motion_state = None
         self._motion_target_position = None

--- a/custom_components/velux_active/entity.py
+++ b/custom_components/velux_active/entity.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+import json
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONTROL_URL, DOMAIN, MANUFACTURER
+from .const import (
+    CONTROL_URL,
+    DOMAIN,
+    MANUFACTURER,
+    VELUX_API_URL,
+    VELUX_APP_TYPE,
+    VELUX_APP_VERSION,
+)
 from .coordinator import VeluxActiveDataUpdateCoordinator
+from .signing import resolve_bridge_id
 
 
 class VeluxActiveEntity(CoordinatorEntity[VeluxActiveDataUpdateCoordinator]):
@@ -42,3 +54,70 @@ class VeluxActiveEntity(CoordinatorEntity[VeluxActiveDataUpdateCoordinator]):
             name=self.module.name,
             sw_version=str(getattr(self.module, "firmware_revision", "")) or None,
         )
+
+    # ------------------------------------------------------------------
+    # Gateway / setstate helpers shared by the control platforms
+    # ------------------------------------------------------------------
+
+    def _get_home(self):
+        """Return the pyatmo Home object that owns this module."""
+        for home in self.coordinator.client._account.homes.values():
+            if self._module_id in home.modules:
+                return home
+        return None
+
+    def _get_bridge_id(self, home) -> str | None:
+        """Return the gateway module ID for this module's owning home.
+
+        Prefer the module's own ``bridge`` link so accounts with multiple
+        gateways route commands to the correct one, only falling back to a
+        home-wide lookup when that home has exactly one gateway.
+        """
+        nxg_ids = [
+            module_id
+            for module_id, module in home.modules.items()
+            if type(module).__name__ == "NXG"
+        ]
+        return resolve_bridge_id(getattr(self.module, "bridge", None), nxg_ids)
+
+    def _get_timezone(self) -> str:
+        """Return the HA configured timezone string."""
+        return str(self.coordinator.hass.config.time_zone)
+
+    async def _async_setstate(
+        self, home, modules: list[dict], *, action: str = "Command"
+    ) -> None:
+        """POST an unsigned setstate request and raise on any failure.
+
+        Used for gateway-level and mode commands that do not need HMAC signing.
+        """
+        payload = {
+            "app_type": VELUX_APP_TYPE,
+            "app_version": VELUX_APP_VERSION,
+            "home": {
+                "id": home.entity_id,
+                "timezone": self._get_timezone(),
+                "modules": modules,
+            },
+        }
+        access_token = await self.coordinator.client._auth.async_get_access_token()
+        session = async_get_clientsession(self.coordinator.hass)
+        async with session.post(
+            f"{VELUX_API_URL}/syncapi/v1/setstate",
+            json=payload,
+            headers={
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            },
+        ) as response:
+            text = await response.text()
+            if not text.strip():
+                raise HomeAssistantError(
+                    f"{action} returned empty response (status {response.status})"
+                )
+            result = json.loads(text)
+            if not response.ok:
+                raise HomeAssistantError(f"{action} failed: {result}")
+            api_errors = result.get("body", {}).get("errors", [])
+            if api_errors:
+                raise HomeAssistantError(f"{action} errors: {api_errors}")

--- a/custom_components/velux_active/switch.py
+++ b/custom_components/velux_active/switch.py
@@ -16,8 +16,12 @@ from .entity import VeluxActiveEntity
 
 _LOGGER = logging.getLogger(__name__)
 
-MODE_ALGO_ENABLED = "auto"
-MODE_ALGO_DISABLED = "algo_disabled"
+# Values the official app writes to toggle the algorithm (from the APK).
+WRITE_MODE_ON = "algo_available"
+WRITE_MODE_OFF = "manual"
+# Modes reported on read. "algo_disabled" is a read-only off state.
+_ON_MODES = frozenset({"algo_available"})
+_OFF_MODES = frozenset({"manual", "algo_disabled"})
 
 
 async def async_setup_entry(
@@ -52,19 +56,21 @@ class VeluxAlgorithmSwitch(VeluxActiveEntity, SwitchEntity):
 
     @property
     def is_on(self) -> bool | None:
-        """Return True when automatic ventilation is active."""
+        """Return True/False for known algorithm modes, None if unknown."""
         mode = getattr(self.module, "mode", None)
-        if mode is None:
-            return None
-        return mode != MODE_ALGO_DISABLED
+        if mode in _ON_MODES:
+            return True
+        if mode in _OFF_MODES:
+            return False
+        return None
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable automatic ventilation."""
-        await self._async_set_mode(MODE_ALGO_ENABLED)
+        await self._async_set_mode(WRITE_MODE_ON)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Disable automatic ventilation."""
-        await self._async_set_mode(MODE_ALGO_DISABLED)
+        await self._async_set_mode(WRITE_MODE_OFF)
 
     async def _async_set_mode(self, mode: str) -> None:
         """Send an unsigned mode setstate command for this window."""

--- a/custom_components/velux_active/switch.py
+++ b/custom_components/velux_active/switch.py
@@ -19,8 +19,9 @@ _LOGGER = logging.getLogger(__name__)
 # Values the official app writes to toggle the algorithm (from the APK).
 WRITE_MODE_ON = "algo_available"
 WRITE_MODE_OFF = "manual"
-# Modes reported on read. "algo_disabled" is a read-only off state.
-_ON_MODES = frozenset({"algo_available"})
+# Modes reported on read. "algo_available"/"algo_active" are algorithm-on
+# states; "algo_disabled" is a read-only off state.
+_ON_MODES = frozenset({"algo_available", "algo_active"})
 _OFF_MODES = frozenset({"manual", "algo_disabled"})
 
 
@@ -43,7 +44,6 @@ class VeluxAlgorithmSwitch(VeluxActiveEntity, SwitchEntity):
     """Switch to enable or disable automatic ventilation for a window."""
 
     _attr_icon = "mdi:air-filter"
-    _attr_name = "Auto Ventilation"
 
     def __init__(
         self,
@@ -52,6 +52,8 @@ class VeluxAlgorithmSwitch(VeluxActiveEntity, SwitchEntity):
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator, module_id)
+        # Set after super().__init__, which resets _attr_name to None.
+        self._attr_name = "Auto Ventilation"
         self._attr_unique_id = f"{module_id}_auto_ventilation"
 
     @property

--- a/custom_components/velux_active/switch.py
+++ b/custom_components/velux_active/switch.py
@@ -1,0 +1,86 @@
+"""Switch platform for VELUX Active automatic ventilation."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .cover import _module_is_window
+from .coordinator import VeluxActiveConfigEntry, VeluxActiveDataUpdateCoordinator
+from .entity import VeluxActiveEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+MODE_ALGO_ENABLED = "auto"
+MODE_ALGO_DISABLED = "algo_disabled"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VeluxActiveConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up VELUX automatic ventilation switches (one per roof window)."""
+    coordinator = entry.runtime_data
+    entities = [
+        VeluxAlgorithmSwitch(coordinator, module_id)
+        for module_id, module in sorted(coordinator.data.covers.items())
+        if _module_is_window(module_id, module)
+    ]
+    async_add_entities(entities)
+
+
+class VeluxAlgorithmSwitch(VeluxActiveEntity, SwitchEntity):
+    """Switch to enable or disable automatic ventilation for a window."""
+
+    _attr_icon = "mdi:air-filter"
+    _attr_name = "Auto Ventilation"
+
+    def __init__(
+        self,
+        coordinator: VeluxActiveDataUpdateCoordinator,
+        module_id: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, module_id)
+        self._attr_unique_id = f"{module_id}_auto_ventilation"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when automatic ventilation is active."""
+        mode = getattr(self.module, "mode", None)
+        if mode is None:
+            return None
+        return mode != MODE_ALGO_DISABLED
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable automatic ventilation."""
+        await self._async_set_mode(MODE_ALGO_ENABLED)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable automatic ventilation."""
+        await self._async_set_mode(MODE_ALGO_DISABLED)
+
+    async def _async_set_mode(self, mode: str) -> None:
+        """Send an unsigned mode setstate command for this window."""
+        home = self._get_home()
+        bridge_id = self._get_bridge_id(home) if home is not None else None
+        if home is None or bridge_id is None:
+            raise HomeAssistantError("Could not find home or gateway")
+
+        _LOGGER.debug(
+            "Setting automatic ventilation mode %s for %s", mode, self._module_id
+        )
+        await self._async_setstate(
+            home,
+            [{"id": self._module_id, "bridge": bridge_id, "mode": mode}],
+            action="Auto ventilation command",
+        )
+
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## Summary

Adds a per-roof-window **Auto Ventilation** switch — the first of the non-core platforms deferred out of #15 to keep that PR focused.

The switch toggles the gateway's ventilation algorithm for a window by sending an **unsigned** `mode` setstate command, so it works without signing keys (only roof-window *movement* needs signing).

- `switch.<window>_auto_ventilation` — On lets the gateway auto-adjust the window via its ventilation algorithm; Off leaves it under manual control only.
- One switch per roof window, using the same window detection as the cover platform.

## Refactor (why cover.py changes)

To avoid copy-pasting logic into a third place, the shared bits move onto the base `VeluxActiveEntity`:

- `_get_home()`, `_get_bridge_id()` (the safe single-gateway resolution from #15), `_get_timezone()`, and an unsigned `_async_setstate()` helper (empty/HTTP/`body.errors` handling).
- The cover **stop** path now calls the shared `_async_setstate()` instead of its own inline POST, so cover.py is net smaller.

This keeps the switch from re-introducing the old first-NXG bridge scan and gives one place for the unsigned setstate behavior.

## Testing

- `python3 -m compileall -q custom_components/velux_active`
- `uvx ruff check custom_components/velux_active tests`
- `python3 tests/test_signing.py` and `python3 tests/test_batch.py` (existing suites still pass; bridge resolution is covered by `resolve_bridge_id` tests)
- Manual: toggled Auto Ventilation on a real roof window.

## Notes

- The `mode` values (`auto` / `algo_disabled`) come from observed API behavior; `is_on` reads `module.mode` and reports unknown if the API doesn't expose it.
- Departure lock and rain binary_sensor (also deferred from #15) will follow in separate PRs.
