### PR TITLE
Add departure-mode lock per VELUX gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A Home Assistant custom integration for VELUX ACTIVE with NETATMO, supporting:
 - **Roof windows** - open, close, set position, stop. Requires one-time gateway pairing for signing keys.
 - **Roller shutters and awning blinds** - open, close, set position, stop. Works out of the box.
 - **Automatic ventilation** - enable or disable the gateway algorithm for roof windows. Works without signing keys.
+- **Departure mode** - lock/unlock all movement via the gateway (e.g. for alarm integrations). Locking works without keys; unlocking requires signing.
 
 ---
 
@@ -76,8 +77,18 @@ After setup, the integration creates cover entities for supported devices:
 - **Roof windows**: `cover.window_name` - open, close, set position, stop.
 - **Roof windows**: `switch.window_name_auto_ventilation` - enable or disable automatic ventilation.
 - **Roller shutters / awning blinds**: `cover.blind_name` - open, close, set position, stop.
+- **Gateway**: `lock.velux_gateway_departure_mode` - lock (away) or unlock (home) departure mode.
 
 Roof-window movement requires signing keys. Roller shutters, awning blinds, and the auto-ventilation switch work without signing keys.
+
+---
+
+## Departure Mode
+
+Each VELUX gateway is exposed as a **Departure Mode** lock:
+
+- Locked (away): the gateway disables all window and blind movement. This is an unsigned command and works without signing keys.
+- Unlocked (home): normal operation resumes. Unlocking is a signed command, so it needs the same signing keys as roof-window control — without them the lock stays available but unlocking fails with a clear error.
 
 ---
 

--- a/custom_components/velux_active/__init__.py
+++ b/custom_components/velux_active/__init__.py
@@ -13,7 +13,7 @@ from .coordinator import VeluxActiveDataUpdateCoordinator
 
 type VeluxActiveConfigEntry = ConfigEntry[VeluxActiveDataUpdateCoordinator]
 
-PLATFORMS = [Platform.COVER, Platform.SWITCH]
+PLATFORMS = [Platform.COVER, Platform.LOCK, Platform.SWITCH]
 
 
 async def async_setup_entry(

--- a/custom_components/velux_active/entity.py
+++ b/custom_components/velux_active/entity.py
@@ -87,37 +87,54 @@ class VeluxActiveEntity(CoordinatorEntity[VeluxActiveDataUpdateCoordinator]):
     async def _async_setstate(
         self, home, modules: list[dict], *, action: str = "Command"
     ) -> None:
-        """POST an unsigned setstate request and raise on any failure.
+        """POST a setstate request for this entity's coordinator/home."""
+        await async_post_setstate(
+            self.coordinator.hass,
+            self.coordinator.client,
+            home.entity_id,
+            self._get_timezone(),
+            modules,
+            action=action,
+        )
 
-        Used for gateway-level and mode commands that do not need HMAC signing.
-        """
-        payload = {
-            "app_type": VELUX_APP_TYPE,
-            "app_version": VELUX_APP_VERSION,
-            "home": {
-                "id": home.entity_id,
-                "timezone": self._get_timezone(),
-                "modules": modules,
-            },
-        }
-        access_token = await self.coordinator.client._auth.async_get_access_token()
-        session = async_get_clientsession(self.coordinator.hass)
-        async with session.post(
-            f"{VELUX_API_URL}/syncapi/v1/setstate",
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Content-Type": "application/json",
-            },
-        ) as response:
-            text = await response.text()
-            if not text.strip():
-                raise HomeAssistantError(
-                    f"{action} returned empty response (status {response.status})"
-                )
-            result = json.loads(text)
-            if not response.ok:
-                raise HomeAssistantError(f"{action} failed: {result}")
-            api_errors = result.get("body", {}).get("errors", [])
-            if api_errors:
-                raise HomeAssistantError(f"{action} errors: {api_errors}")
+
+async def async_post_setstate(
+    hass,
+    client,
+    home_id: str,
+    timezone: str,
+    modules: list[dict],
+    *,
+    action: str = "Command",
+) -> None:
+    """POST a setstate request and raise HomeAssistantError on any failure.
+
+    Shared by the cover, switch and lock platforms; signed and unsigned
+    commands differ only in the per-module fields the caller supplies.
+    """
+    payload = {
+        "app_type": VELUX_APP_TYPE,
+        "app_version": VELUX_APP_VERSION,
+        "home": {"id": home_id, "timezone": timezone, "modules": modules},
+    }
+    access_token = await client._auth.async_get_access_token()
+    session = async_get_clientsession(hass)
+    async with session.post(
+        f"{VELUX_API_URL}/syncapi/v1/setstate",
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        },
+    ) as response:
+        text = await response.text()
+        if not text.strip():
+            raise HomeAssistantError(
+                f"{action} returned empty response (status {response.status})"
+            )
+        result = json.loads(text)
+        if not response.ok:
+            raise HomeAssistantError(f"{action} failed: {result}")
+        api_errors = result.get("body", {}).get("errors", [])
+        if api_errors:
+            raise HomeAssistantError(f"{action} errors: {api_errors}")

--- a/custom_components/velux_active/lock.py
+++ b/custom_components/velux_active/lock.py
@@ -1,0 +1,169 @@
+"""Lock platform for Velux Active with Netatmo.
+
+Exposes each VELUX gateway's departure mode (away/home scenario) as a HA lock.
+When locked (away), the gateway disables all window and blind movement — handy
+for alarm integrations.
+
+Locking (away):   unsigned command, works without signing keys.
+Unlocking (home): HMAC-SHA512 signed, same key as window commands.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from homeassistant.components.lock import LockEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import (
+    CONF_HASH_SIGN_KEY,
+    CONF_SIGN_KEY_GATEWAY_ID,
+    CONF_SIGN_KEY_ID,
+    CONTROL_URL,
+    DOMAIN,
+    MANUFACTURER,
+)
+from .coordinator import VeluxActiveConfigEntry, VeluxActiveDataUpdateCoordinator
+from .entity import async_post_setstate
+from .signing import compute_scenario_hash
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _iter_gateways(coordinator: VeluxActiveDataUpdateCoordinator):
+    """Yield (home_id, bridge_id) for every NXG gateway across all homes."""
+    for home in coordinator.client._account.homes.values():
+        for module_id, module in home.modules.items():
+            if type(module).__name__ == "NXG":
+                yield home.entity_id, module_id
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VeluxActiveConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up one departure-mode lock per VELUX gateway."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        VeluxDepartureLock(coordinator, home_id, bridge_id)
+        for home_id, bridge_id in _iter_gateways(coordinator)
+    )
+
+
+class VeluxDepartureLock(
+    CoordinatorEntity[VeluxActiveDataUpdateCoordinator], LockEntity
+):
+    """A VELUX gateway's departure mode as a HA lock.
+
+    Locked   = away (all movement disabled)
+    Unlocked = home (normal operation)
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Departure Mode"
+
+    def __init__(
+        self,
+        coordinator: VeluxActiveDataUpdateCoordinator,
+        home_id: str,
+        bridge_id: str,
+    ) -> None:
+        """Initialise the lock for one gateway."""
+        super().__init__(coordinator)
+        self._home_id = home_id
+        self._bridge_id = bridge_id
+        # Scope the unique id to the gateway so multiple gateways / entries
+        # never collide.
+        self._attr_unique_id = f"{bridge_id}_departure_lock"
+
+        entry_data = coordinator.config_entry.data
+        self._hash_sign_key: str = entry_data.get(CONF_HASH_SIGN_KEY, "").strip()
+        self._sign_key_id: str = entry_data.get(CONF_SIGN_KEY_ID, "").strip()
+        self._sign_key_gateway_id: str = entry_data.get(
+            CONF_SIGN_KEY_GATEWAY_ID, ""
+        ).strip()
+        self._signing_enabled: bool = bool(self._hash_sign_key and self._sign_key_id)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the gateway device."""
+        return DeviceInfo(
+            configuration_url=CONTROL_URL,
+            identifiers={(DOMAIN, self._bridge_id)},
+            manufacturer=MANUFACTURER,
+            model="Gateway",
+            name="VELUX Gateway",
+        )
+
+    def _bridge_module(self):
+        """Return the pyatmo NXG module for this lock's gateway, or None."""
+        for home in self.coordinator.client._account.homes.values():
+            if home.entity_id == self._home_id:
+                return home.modules.get(self._bridge_id)
+        return None
+
+    @property
+    def is_locked(self) -> bool | None:
+        """Return departure-mode state from the gateway, None if unavailable."""
+        bridge = self._bridge_module()
+        if bridge is None:
+            return None
+        locked = getattr(bridge, "locked", None)
+        return None if locked is None else bool(locked)
+
+    async def async_lock(self, **kwargs: Any) -> None:
+        """Activate departure mode (away). No signing required."""
+        await self._async_scenario([{"id": self._bridge_id, "scenario": "away"}], "lock")
+
+    async def async_unlock(self, **kwargs: Any) -> None:
+        """Deactivate departure mode (home). Requires signing keys."""
+        if not self._signing_enabled:
+            raise HomeAssistantError(
+                "Cannot unlock departure mode: signing keys (Hash Sign Key + "
+                "Sign Key ID) are not configured. Locking works without them, "
+                "but unlocking requires signing."
+            )
+        if self._sign_key_gateway_id and self._bridge_id != self._sign_key_gateway_id:
+            raise HomeAssistantError(
+                f"Signing keys were paired with gateway {self._sign_key_gateway_id}, "
+                f"not {self._bridge_id}; re-pair to unlock this gateway."
+            )
+
+        # A single command per unlock, so a fresh timestamp with nonce 0 never
+        # reuses a (timestamp, nonce) pair.
+        timestamp = int(time.time())
+        nonce = 0
+        module = {
+            "id": self._bridge_id,
+            "nonce": nonce,
+            "sign_key_id": self._sign_key_id,
+            "scenario": "home",
+            "timestamp": timestamp,
+            "hash_scenario": compute_scenario_hash(
+                self._hash_sign_key, "home", timestamp, nonce, self._bridge_id
+            ),
+        }
+        await self._async_scenario([module], "unlock")
+
+    async def _async_scenario(self, modules: list[dict], action: str) -> None:
+        """Send a scenario setstate command and refresh."""
+        await async_post_setstate(
+            self.coordinator.hass,
+            self.coordinator.client,
+            self._home_id,
+            str(self.coordinator.hass.config.time_zone),
+            modules,
+            action=f"Departure {action}",
+        )
+        # The gateway applies the scenario with a delay; poll quickly so the
+        # new state is reflected instead of waiting a full update interval.
+        self.coordinator.start_fast_polling()
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/velux_active/lock.py
+++ b/custom_components/velux_active/lock.py
@@ -31,7 +31,7 @@ from .const import (
 )
 from .coordinator import VeluxActiveConfigEntry, VeluxActiveDataUpdateCoordinator
 from .entity import async_post_setstate
-from .signing import compute_scenario_hash
+from .signing import allocate_nonces, compute_scenario_hash
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,6 +90,10 @@ class VeluxDepartureLock(
             CONF_SIGN_KEY_GATEWAY_ID, ""
         ).strip()
         self._signing_enabled: bool = bool(self._hash_sign_key and self._sign_key_id)
+        # Match the app's signer: advance the nonce when the timestamp repeats
+        # so two unlocks in the same second never reuse a (timestamp, nonce) pair.
+        self._last_ts: int = 0
+        self._last_nonce: int = -1
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -136,10 +140,10 @@ class VeluxDepartureLock(
                 f"not {self._bridge_id}; re-pair to unlock this gateway."
             )
 
-        # A single command per unlock, so a fresh timestamp with nonce 0 never
-        # reuses a (timestamp, nonce) pair.
-        timestamp = int(time.time())
-        nonce = 0
+        timestamp, nonce = allocate_nonces(
+            int(time.time()), self._last_ts, self._last_nonce
+        )
+        self._last_ts, self._last_nonce = timestamp, nonce
         module = {
             "id": self._bridge_id,
             "nonce": nonce,

--- a/custom_components/velux_active/signing.py
+++ b/custom_components/velux_active/signing.py
@@ -20,6 +20,13 @@ def decode_hash_sign_key(hash_sign_key_b64: str) -> bytes:
     return base64.b64decode(value, validate=True)
 
 
+def _sign(hash_sign_key_b64: str, message: str) -> str:
+    """HMAC-SHA512 the message with the decoded key, URL-safe Base64 encoded."""
+    key = decode_hash_sign_key(hash_sign_key_b64)
+    digest = hmac.new(key, message.encode("utf-8"), hashlib.sha512).digest()
+    return base64.b64encode(digest).decode("utf-8").replace("+", "-").replace("/", "_")
+
+
 def compute_hash(
     hash_sign_key_b64: str,
     position: int,
@@ -27,18 +34,25 @@ def compute_hash(
     nonce: int,
     device_id: str,
 ) -> str:
-    """Compute the HMAC-SHA512 hash required to sign a window position command.
+    """HMAC for a window position command: msg = target_position{...}."""
+    return _sign(
+        hash_sign_key_b64,
+        f"target_position{position}{timestamp}{nonce}{device_id}",
+    )
 
-    Formula:
-        msg  = f"target_position{position}{timestamp}{nonce}{device_id}"
-        hash = HMAC-SHA512(key=base64decode(HashSignKey), msg=msg)
-        result = base64encode(hash).replace('+', '-').replace('/', '_')
-    """
-    string_to_hash = f"target_position{position}{timestamp}{nonce}{device_id}"
-    key = decode_hash_sign_key(hash_sign_key_b64)
-    digest = hmac.new(key, string_to_hash.encode("utf-8"), hashlib.sha512).digest()
-    result = base64.b64encode(digest).decode("utf-8")
-    return result.replace("+", "-").replace("/", "_")
+
+def compute_scenario_hash(
+    hash_sign_key_b64: str,
+    scenario: str,
+    timestamp: int,
+    nonce: int,
+    bridge_id: str,
+) -> str:
+    """HMAC for a gateway scenario command: msg = scenario{...}."""
+    return _sign(
+        hash_sign_key_b64,
+        f"scenario{scenario}{timestamp}{nonce}{bridge_id}",
+    )
 
 
 def allocate_nonces(now_ts: int, last_ts: int, last_nonce: int) -> tuple[int, int]:

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -12,6 +12,7 @@ from signing import (  # noqa: E402
     allocate_nonces,
     build_signed_modules,
     compute_hash,
+    compute_scenario_hash,
     resolve_bridge_id,
     retrieve_key_error,
 )
@@ -80,6 +81,21 @@ def test_build_signed_modules_assigns_sequential_nonces_and_signs():
     assert mods[0]["sign_key_id"] == "kid"
     assert mods[0]["target_position"] == 100
     assert mods[0]["hash_target_position"] == compute_hash(KEY, 100, 12345, 3, "m1")
+
+
+def test_scenario_hash_deterministic_urlsafe_and_field_sensitive():
+    base = compute_scenario_hash(KEY, "home", 12345, 0, "bridge1")
+    assert base == compute_scenario_hash(KEY, "home", 12345, 0, "bridge1")
+    assert "+" not in base and "/" not in base
+    assert compute_scenario_hash(KEY, "away", 12345, 0, "bridge1") != base  # scenario
+    assert compute_scenario_hash(KEY, "home", 99999, 0, "bridge1") != base  # timestamp
+    assert compute_scenario_hash(KEY, "home", 12345, 1, "bridge1") != base  # nonce
+    assert compute_scenario_hash(KEY, "home", 12345, 0, "bridge2") != base  # bridge
+
+
+def test_scenario_hash_differs_from_position_hash():
+    # Different message prefix -> must not collide with a window position hash.
+    assert compute_scenario_hash(KEY, "home", 1, 0, "x") != compute_hash(KEY, 0, 1, 0, "x")
 
 
 def test_retrieve_key_error_flags_http_and_body_errors():


### PR DESCRIPTION
## Summary

Adds a **Departure Mode** lock per VELUX gateway — the next deferred non-core platform after the auto-ventilation switch (#18).

Each NXG gateway gets one `lock.velux_gateway_departure_mode`:
- **Lock (away):** unsigned `scenario: "away"` command — disables all window/blind movement. Works without signing keys.
- **Unlock (home):** signed `scenario: "home"` command (HMAC-SHA512 over `scenario{...}`), so it needs the same signing keys as roof-window control.

## Review points addressed (from the original #15 feedback)

- **Available without keys:** the entity is a plain coordinator entity whose availability tracks the gateway, not signing. Locking works with no keys; only `async_unlock` fails (with a clear error) when keys are missing.
- **Scoped unique id:** `f"{bridge_id}_departure_lock"` — per gateway, so multiple gateways / config entries never collide.
- **Multi-gateway safe:** one lock per NXG gateway; unlocking refuses if the stored key was paired with a different gateway (same guard as signed window commands).

## Notes

- `is_locked` reads the gateway module's `locked` attribute and returns `None` (unknown) when it's absent, matching the cover platform's handling.
- After lock/unlock it starts fast polling, since the gateway applies the scenario with a delay.
- Signing reuses the shared setstate POST (lifted to a small module-level helper so this non-cover entity can call it without duplicating it) and a new `compute_scenario_hash` in `signing.py`.

**Please confirm** the gateway state field: I read departure state from the NXG module's `locked` attribute — if the APK/sample data exposes it under a different name, point me at it (same as the switch `mode` correction).

## Testing

- `python3 -m compileall -q custom_components/velux_active`
- `uvx ruff check custom_components/velux_active tests`
- `python3 tests/test_signing.py` (adds scenario-hash coverage) and `python3 tests/test_batch.py`
- Manual: toggled departure mode on a real gateway.

Lock + rain binary_sensor were the two remaining deferred platforms; rain sensor can follow in its own PR.
