### PR TITLE
Add controlled opener selection for climate sensors

### DIFF
--- a/client.py
+++ b/client.py
@@ -65,6 +65,7 @@ DEFAULT_SYNC_BASE_URL = "https://app.velux-active.com"
 DEFAULT_APP_TYPE = "app_velux"
 DEFAULT_TIMEZONE = "UTC"
 BATTERY_MODULE_TYPES = frozenset({"NXS", "NXD"})
+CONTROLLED_OPENERS_OPTIONS = ("windows", "external_covers")
 ROOM_MEASUREMENT_KEYS = (
     "temperature",
     "co2",
@@ -520,6 +521,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Home ID or exact name; omitted only when the account has one home",
     )
 
+    set_controlled_openers_parser = subparsers.add_parser(
+        "set-controlled-openers",
+        parents=[auth_parent],
+        help="Set which products an indoor climate sensor controls",
+    )
+    set_controlled_openers_parser.add_argument(
+        "module",
+        help="NXS module ID or exact name",
+    )
+    set_controlled_openers_parser.add_argument(
+        "controlled_openers",
+        choices=CONTROLLED_OPENERS_OPTIONS,
+        help="Products controlled by the indoor climate sensor",
+    )
+
     set_position_parser = subparsers.add_parser(
         "set-cover-position",
         parents=[auth_parent],
@@ -655,6 +671,25 @@ async def command_get_configs(args: argparse.Namespace) -> dict[str, Any]:
         homesdata = await post_api_json(auth, GETHOMESDATA_ENDPOINT)
         home_id = resolve_home_id(homesdata, args.home)
         return await get_sync_configs(auth, args, home_id=home_id)
+
+
+async def command_set_controlled_openers(args: argparse.Namespace) -> dict[str, Any]:
+    """Handle the set-controlled-openers command."""
+
+    async with aiohttp.ClientSession() as websession:
+        auth = build_auth(args, websession)
+        homesdata = await post_api_json(auth, GETHOMESDATA_ENDPOINT)
+        home_id, module_id, bridge_id = resolve_controlled_openers_target(
+            homesdata, args.module
+        )
+        return await set_sync_controlled_openers(
+            auth,
+            args,
+            home_id=home_id,
+            module_id=module_id,
+            bridge_id=bridge_id,
+            controlled_openers=args.controlled_openers,
+        )
 
 
 async def command_set_cover_position(args: argparse.Namespace) -> dict[str, Any]:
@@ -896,31 +931,93 @@ async def get_sync_configs(
 ) -> dict[str, Any]:
     """GET the raw VELUX app sync configuration for one home."""
 
-    access_token = await auth.async_get_access_token()
-    url = f"{args.sync_base_url.rstrip('/')}/syncapi/v1/getconfigs"
-    timeout = aiohttp.ClientTimeout(total=args.timeout)
-    async with auth.websession.get(
-        url,
+    return await request_sync_json(
+        auth,
+        args,
+        method="GET",
+        endpoint="getconfigs",
         params={"home_id": home_id},
-        headers={"Authorization": f"Bearer {access_token}"},
-        timeout=timeout,
-    ) as response:
+    )
+
+
+async def set_sync_controlled_openers(
+    auth: VeluxAsyncAuth,
+    args: argparse.Namespace,
+    *,
+    home_id: str,
+    module_id: str,
+    bridge_id: str,
+    controlled_openers: str,
+) -> dict[str, Any]:
+    """POST one indoor climate sensor control target to setconfigs."""
+
+    if controlled_openers not in CONTROLLED_OPENERS_OPTIONS:
+        raise ValueError(f"Unsupported controlled_openers: {controlled_openers}")
+
+    return await request_sync_json(
+        auth,
+        args,
+        method="POST",
+        endpoint="setconfigs",
+        json_payload={
+            "home_id": home_id,
+            "home": {
+                "modules": [
+                    {
+                        "id": module_id,
+                        "bridge": bridge_id,
+                        "controlled_openers": controlled_openers,
+                    }
+                ]
+            },
+        },
+    )
+
+
+async def request_sync_json(
+    auth: VeluxAsyncAuth,
+    args: argparse.Namespace,
+    *,
+    method: str,
+    endpoint: str,
+    params: dict[str, str] | None = None,
+    json_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Send an authenticated VELUX sync API request and return JSON."""
+
+    access_token = await auth.async_get_access_token()
+    url = f"{args.sync_base_url.rstrip('/')}/syncapi/v1/{endpoint}"
+    timeout = aiohttp.ClientTimeout(total=args.timeout)
+    headers = {"Authorization": f"Bearer {access_token}"}
+    request_kwargs: dict[str, Any] = {"headers": headers, "timeout": timeout}
+    if params is not None:
+        request_kwargs["params"] = params
+    if json_payload is not None:
+        headers["Content-Type"] = "application/json"
+        request_kwargs["json"] = json_payload
+
+    request = getattr(auth.websession, method.lower())
+    async with request(url, **request_kwargs) as response:
         text = await response.text()
 
     if not text.strip():
         raise RuntimeError(
-            f"getconfigs returned empty response (status {response.status})"
+            f"{endpoint} returned empty response (status {response.status})"
         )
 
     try:
         raw: Any = json.loads(text)
-    except json.JSONDecodeError:
-        raw = {"raw": text}
+    except json.JSONDecodeError as err:
+        raise RuntimeError(f"{endpoint} returned an invalid JSON response") from err
 
     if not response.ok:
-        raise RuntimeError(f"getconfigs failed with status {response.status}: {raw}")
+        raise RuntimeError(f"{endpoint} failed with status {response.status}: {raw}")
     if not isinstance(raw, dict):
-        raise RuntimeError(f"Unexpected getconfigs response: {raw!r}")
+        raise RuntimeError(f"Unexpected {endpoint} response: {raw!r}")
+    body = raw.get("body")
+    errors = body.get("errors") if isinstance(body, dict) else None
+    if raw.get("status") != "ok" or errors:
+        raise RuntimeError(f"{endpoint} failed: {raw}")
     return raw
 
 
@@ -1061,6 +1158,55 @@ def resolve_home_id(raw_homesdata: dict[str, Any], home_ref: str | None) -> str:
 
     available = [f"{home.get('name')} ({home.get('id')})" for home in homes]
     raise ValueError(f"Home '{home_ref}' not found. Available homes: {available}")
+
+
+def resolve_controlled_openers_target(
+    raw_homesdata: dict[str, Any], module_ref: str
+) -> tuple[str, str, str]:
+    """Resolve an NXS module and its home and bridge from raw homesdata."""
+    body = raw_homesdata.get("body")
+    homes = body.get("homes", []) if isinstance(body, dict) else []
+    candidates = [
+        (home, module)
+        for home in homes
+        if isinstance(home, dict)
+        for module in home.get("modules") or []
+        if isinstance(module, dict) and module.get("type") == "NXS"
+    ]
+
+    id_matches = [
+        (home, module)
+        for home, module in candidates
+        if str(module.get("id")) == module_ref
+    ]
+    if len(id_matches) == 1:
+        home, module = id_matches[0]
+    else:
+        name_matches = [
+            (home, module)
+            for home, module in candidates
+            if str(module.get("name") or "").casefold() == module_ref.casefold()
+        ]
+        if len(name_matches) == 1:
+            home, module = name_matches[0]
+        elif len(name_matches) > 1:
+            matches = [str(module.get("id")) for _, module in name_matches]
+            raise ValueError(f"NXS module name '{module_ref}' is ambiguous: {matches}")
+        else:
+            available = [
+                f"{home.get('name')} / {module.get('name')} ({module.get('id')})"
+                for home, module in candidates
+            ]
+            raise ValueError(
+                f"NXS module '{module_ref}' not found. Available modules: {available}"
+            )
+
+    home_id = str(home.get("id") or "")
+    module_id = str(module.get("id") or "")
+    bridge_id = str(module.get("bridge") or "")
+    if not home_id or not module_id or not bridge_id:
+        raise ValueError(f"NXS module '{module_ref}' is missing home or bridge data")
+    return home_id, module_id, bridge_id
 
 
 def resolve_module_bridge_id(
@@ -1492,6 +1638,8 @@ async def run(args: argparse.Namespace) -> dict[str, Any]:
         return await command_raw_homestatus(args)
     if args.command == "get-configs":
         return await command_get_configs(args)
+    if args.command == "set-controlled-openers":
+        return await command_set_controlled_openers(args)
     if args.command == "set-cover-position":
         return await command_set_cover_position(args)
     if args.command == "stop-cover":

--- a/custom_components/velux_active/__init__.py
+++ b/custom_components/velux_active/__init__.py
@@ -18,6 +18,7 @@ PLATFORMS = [
     Platform.BUTTON,
     Platform.COVER,
     Platform.LOCK,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
 ]

--- a/custom_components/velux_active/api.py
+++ b/custom_components/velux_active/api.py
@@ -295,9 +295,7 @@ class VeluxActiveClient:
             token_updated=token_updated,
         )
         self._account = AsyncAccount(self._auth)
-        self._controlled_openers_by_home: dict[
-            str, dict[str, dict[str, str]]
-        ] = {}
+        self._controlled_openers_by_home: dict[str, dict[str, dict[str, str]]] = {}
 
     async def async_validate(self) -> None:
         """Validate credentials by loading account topology and status."""
@@ -528,8 +526,8 @@ class VeluxActiveClient:
                     err,
                 )
             else:
-                self._controlled_openers_by_home[home_id] = (
-                    _extract_controlled_openers(home_id, raw_configs)
+                self._controlled_openers_by_home[home_id] = _extract_controlled_openers(
+                    home_id, raw_configs
                 )
 
         controlled_openers = {

--- a/custom_components/velux_active/api.py
+++ b/custom_components/velux_active/api.py
@@ -30,7 +30,11 @@ from .const import (
     CONF_ACCESS_TOKEN,
     CONF_REFRESH_TOKEN,
     CONF_TOKEN_EXPIRES_AT,
+    CONTROLLED_OPENERS_OPTIONS,
+    GETCONFIGS_ENDPOINT,
     LOGGER,
+    SETCONFIGS_ENDPOINT,
+    VELUX_API_URL,
 )
 from .signing import retrieve_key_error
 
@@ -95,6 +99,7 @@ class VeluxActiveData:
     gateway_status: dict[str, dict[str, Any]]
     rooms: dict[str, dict[str, Any]]
     sensor_modules: dict[str, dict[str, Any]]
+    controlled_openers: dict[str, dict[str, str]]
 
 
 BATTERY_MODULE_TYPES = frozenset({"NXS", "NXD"})
@@ -290,6 +295,9 @@ class VeluxActiveClient:
             token_updated=token_updated,
         )
         self._account = AsyncAccount(self._auth)
+        self._controlled_openers_by_home: dict[
+            str, dict[str, dict[str, str]]
+        ] = {}
 
     async def async_validate(self) -> None:
         """Validate credentials by loading account topology and status."""
@@ -310,6 +318,102 @@ class VeluxActiveClient:
             params={"home_id": home_id},
         )
         return await response.json()
+
+    async def async_get_configs(self, home_id: str) -> dict[str, Any]:
+        """Return the VELUX app configuration for one home."""
+        return await self._async_sync_api_request(
+            "GET",
+            GETCONFIGS_ENDPOINT,
+            params={"home_id": home_id},
+        )
+
+    async def async_set_controlled_openers(
+        self,
+        home_id: str,
+        module_id: str,
+        bridge_id: str,
+        controlled_openers: str,
+    ) -> None:
+        """Set which opening type an indoor climate sensor controls."""
+        if controlled_openers not in CONTROLLED_OPENERS_OPTIONS:
+            raise ValueError(f"Unsupported controlled_openers: {controlled_openers}")
+
+        await self._async_sync_api_request(
+            "POST",
+            SETCONFIGS_ENDPOINT,
+            json_data={
+                "home_id": home_id,
+                "home": {
+                    "modules": [
+                        {
+                            "id": module_id,
+                            "bridge": bridge_id,
+                            "controlled_openers": controlled_openers,
+                        }
+                    ]
+                },
+            },
+        )
+        self._controlled_openers_by_home.setdefault(home_id, {})[module_id] = {
+            "home_id": home_id,
+            "bridge": bridge_id,
+            "controlled_openers": controlled_openers,
+        }
+
+    async def _async_sync_api_request(
+        self,
+        method: str,
+        endpoint: str,
+        *,
+        params: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Send an authenticated request to the VELUX sync API."""
+        access_token = await self._auth.async_get_access_token()
+        headers = {"Authorization": f"Bearer {access_token}"}
+        request_kwargs: dict[str, Any] = {
+            "headers": headers,
+            "timeout": aiohttp.ClientTimeout(total=DEFAULT_TIMEOUT),
+        }
+        if params is not None:
+            request_kwargs["params"] = params
+        if json_data is not None:
+            headers["Content-Type"] = "application/json"
+            request_kwargs["json"] = json_data
+
+        try:
+            async with self._auth.websession.request(
+                method,
+                f"{VELUX_API_URL}{endpoint}",
+                **request_kwargs,
+            ) as response:
+                text = await response.text()
+        except (aiohttp.ClientError, TimeoutError) as err:
+            raise VeluxActiveCannotConnect(str(err)) from err
+
+        if not text.strip():
+            raise VeluxActiveCannotConnect(
+                f"{endpoint} returned empty response (status {response.status})"
+            )
+        try:
+            raw: Any = json.loads(text)
+        except JSONDecodeError as err:
+            raise VeluxActiveCannotConnect(
+                f"{endpoint} returned an invalid JSON response"
+            ) from err
+
+        body = raw.get("body") if isinstance(raw, dict) else None
+        errors = body.get("errors") if isinstance(body, dict) else None
+        if (
+            not response.ok
+            or not isinstance(raw, dict)
+            or raw.get("status") != "ok"
+            or errors
+        ):
+            raise VeluxActiveCannotConnect(
+                f"{endpoint} failed with status {response.status}: {raw}"
+            )
+        return raw
 
     async def async_trigger_retrieve_key(self, home_id: str, gateway_id: str) -> None:
         """Ask the gateway to open its temporary local key retrieval listener."""
@@ -408,6 +512,33 @@ class VeluxActiveClient:
         rooms, sensor_modules = _extract_climate_status(
             self._account.homes, raw_status_by_home_id
         )
+        nxs_home_ids = {
+            str(module["home_id"])
+            for module in sensor_modules.values()
+            if module.get("type") == "NXS" and module.get("home_id")
+        }
+        for home_id in sorted(nxs_home_ids):
+            try:
+                raw_configs = await self.async_get_configs(home_id)
+            except VeluxActiveCannotConnect as err:
+                LOGGER.debug(
+                    "Keeping previous VELUX controlled opener configuration: "
+                    "home_id=%s error=%s",
+                    home_id,
+                    err,
+                )
+            else:
+                self._controlled_openers_by_home[home_id] = (
+                    _extract_controlled_openers(home_id, raw_configs)
+                )
+
+        controlled_openers = {
+            module_id: dict(config)
+            for home_configs in self._controlled_openers_by_home.values()
+            for module_id, config in home_configs.items()
+            if module_id in sensor_modules
+            and sensor_modules[module_id].get("type") == "NXS"
+        }
         gateway_connectivity = _extract_gateway_connectivity(
             self._account.homes, raw_status_by_home_id
         )
@@ -423,6 +554,7 @@ class VeluxActiveClient:
             gateway_status=gateway_status,
             rooms=rooms,
             sensor_modules=sensor_modules,
+            controlled_openers=controlled_openers,
         )
 
     @property
@@ -526,6 +658,28 @@ def _extract_climate_status(
             sensor_modules[module_id] = module_data
 
     return rooms, sensor_modules
+
+
+def _extract_controlled_openers(
+    home_id: str, raw_configs: Mapping[str, Any]
+) -> dict[str, dict[str, str]]:
+    """Extract per-NXS controlled opener settings from getconfigs."""
+    configs: dict[str, dict[str, str]] = {}
+    raw_home = _raw_status_home(raw_configs)
+    for raw_module in raw_home.get("modules") or []:
+        if not isinstance(raw_module, Mapping):
+            continue
+        module_id = str(raw_module.get("id") or "")
+        bridge_id = str(raw_module.get("bridge") or "")
+        controlled_openers = raw_module.get("controlled_openers")
+        if not module_id or not bridge_id or not isinstance(controlled_openers, str):
+            continue
+        configs[module_id] = {
+            "home_id": home_id,
+            "bridge": bridge_id,
+            "controlled_openers": controlled_openers,
+        }
+    return configs
 
 
 def _raw_status_home(raw_status: Mapping[str, Any]) -> dict[str, Any]:

--- a/custom_components/velux_active/const.py
+++ b/custom_components/velux_active/const.py
@@ -22,4 +22,8 @@ VELUX_API_URL = "https://app.velux-active.com"
 VELUX_APP_TYPE = "app_velux"
 VELUX_APP_VERSION = "791302006"
 
+GETCONFIGS_ENDPOINT = "/syncapi/v1/getconfigs"
+SETCONFIGS_ENDPOINT = "/syncapi/v1/setconfigs"
+CONTROLLED_OPENERS_OPTIONS = ("windows", "external_covers")
+
 LOGGER = logging.getLogger(__package__)

--- a/custom_components/velux_active/select.py
+++ b/custom_components/velux_active/select.py
@@ -1,0 +1,138 @@
+"""Select platform for VELUX indoor climate sensor control targets."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .api import VeluxActiveCannotConnect
+from .const import (
+    CONTROL_URL,
+    CONTROLLED_OPENERS_OPTIONS,
+    DOMAIN,
+    MANUFACTURER,
+)
+from .coordinator import VeluxActiveConfigEntry, VeluxActiveDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: VeluxActiveConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up controlled-product selects for NXS modules."""
+    coordinator = entry.runtime_data
+    known_modules: set[str] = set()
+
+    @callback
+    def _async_add_new_entities() -> None:
+        entities: list[SelectEntity] = []
+        for module_id in sorted(coordinator.data.controlled_openers):
+            module = coordinator.data.sensor_modules.get(module_id, {})
+            if module.get("type") != "NXS" or module_id in known_modules:
+                continue
+            entities.append(VeluxControlledOpenersSelect(coordinator, module_id))
+            known_modules.add(module_id)
+
+        if entities:
+            async_add_entities(entities)
+
+    _async_add_new_entities()
+    entry.async_on_unload(coordinator.async_add_listener(_async_add_new_entities))
+
+
+class VeluxControlledOpenersSelect(
+    CoordinatorEntity[VeluxActiveDataUpdateCoordinator], SelectEntity
+):
+    """Select which products an indoor climate sensor controls."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Controlled products"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_options: ClassVar[list[str]] = list(CONTROLLED_OPENERS_OPTIONS)
+
+    def __init__(
+        self,
+        coordinator: VeluxActiveDataUpdateCoordinator,
+        module_id: str,
+    ) -> None:
+        """Initialize the controlled-products select."""
+        super().__init__(coordinator)
+        self._module_id = module_id
+        self._attr_unique_id = f"{module_id}_controlled_openers"
+
+    @property
+    def _config(self) -> dict[str, str]:
+        """Return the current controlled opener configuration."""
+        return self.coordinator.data.controlled_openers.get(self._module_id, {})
+
+    @property
+    def _module(self) -> dict[str, Any]:
+        """Return the current physical module data."""
+        return self.coordinator.data.sensor_modules.get(self._module_id, {})
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the currently configured control target."""
+        option = self._config.get("controlled_openers")
+        return option if option in CONTROLLED_OPENERS_OPTIONS else None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach the select to the physical indoor climate sensor."""
+        module = self._module
+        firmware_revision = module.get("firmware_revision")
+        return DeviceInfo(
+            configuration_url=CONTROL_URL,
+            identifiers={(DOMAIN, self._module_id)},
+            manufacturer=MANUFACTURER,
+            model="Indoor Climate Sensor",
+            name=module.get("name") or self._module_id,
+            suggested_area=module.get("room_name"),
+            sw_version=str(firmware_revision)
+            if firmware_revision is not None
+            else None,
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return whether the module has a supported current configuration."""
+        return (
+            super().available
+            and self._module.get("type") == "NXS"
+            and self.current_option is not None
+        )
+
+    async def async_select_option(self, option: str) -> None:
+        """Set which products this indoor climate sensor controls."""
+        if option not in CONTROLLED_OPENERS_OPTIONS:
+            raise HomeAssistantError(f"Unsupported controlled product: {option}")
+
+        config = self._config
+        home_id = config.get("home_id")
+        bridge_id = config.get("bridge")
+        if not home_id or not bridge_id:
+            raise HomeAssistantError("Could not find home or gateway")
+
+        try:
+            await self.coordinator.client.async_set_controlled_openers(
+                home_id,
+                self._module_id,
+                bridge_id,
+                option,
+            )
+        except VeluxActiveCannotConnect as err:
+            raise HomeAssistantError(
+                f"Failed to update controlled products: {err}"
+            ) from err
+
+        config["controlled_openers"] = option
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()

--- a/custom_components/velux_active/sensor.py
+++ b/custom_components/velux_active/sensor.py
@@ -13,12 +13,12 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
-    CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfElectricPotential,
+    UnitOfRatio,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -92,7 +92,7 @@ ROOM_SENSORS: tuple[VeluxRoomSensorDescription, ...] = (
         key="co2",
         name="CO2",
         device_class=SensorDeviceClass.CO2,
-        native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+        native_unit_of_measurement=UnitOfRatio.PARTS_PER_MILLION,
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda room: room.get("co2"),
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,7 +151,6 @@ _install_module(
 )
 _install_module(
     "homeassistant.const",
-    CONCENTRATION_PARTS_PER_MILLION="ppm",
     CONF_PASSWORD="password",
     CONF_USERNAME="username",
     LIGHT_LUX="lx",
@@ -159,6 +158,7 @@ _install_module(
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT="dBm",
     EntityCategory=SimpleNamespace(CONFIG="config", DIAGNOSTIC="diagnostic"),
     UnitOfElectricPotential=SimpleNamespace(VOLT="V"),
+    UnitOfRatio=SimpleNamespace(PARTS_PER_MILLION="ppm"),
     UnitOfTemperature=SimpleNamespace(CELSIUS="°C"),
 )
 _install_module(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -135,6 +135,10 @@ _install_module(
     SensorStateClass=SimpleNamespace(MEASUREMENT="measurement"),
 )
 _install_module(
+    "homeassistant.components.select",
+    SelectEntity=Stub,
+)
+_install_module(
     "homeassistant.components.switch",
     SwitchEntity=Stub,
 )

--- a/tests/test_api_configs.py
+++ b/tests/test_api_configs.py
@@ -1,0 +1,233 @@
+"""Tests for VELUX controlled opener configuration requests."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from velux_active.api import (
+    VeluxActiveCannotConnect,
+    VeluxActiveClient,
+    _extract_controlled_openers,
+)
+
+
+class FakeResponse:
+    """Minimal aiohttp response context manager."""
+
+    def __init__(self, payload, *, status=200):
+        self.payload = payload
+        self.status = status
+        self.ok = status < 400
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return None
+
+    async def text(self):
+        return json.dumps(self.payload)
+
+
+class FakeSession:
+    """Capture sync API requests."""
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.requests = []
+
+    def request(self, method, url, **kwargs):
+        self.requests.append((method, url, kwargs))
+        return FakeResponse(self.payload)
+
+
+def _client_with_response(payload):
+    client = object.__new__(VeluxActiveClient)
+    session = FakeSession(payload)
+    client._auth = SimpleNamespace(
+        websession=session,
+        async_get_access_token=AsyncMock(return_value="access-token"),
+    )
+    client._controlled_openers_by_home = {}
+    return client, session
+
+
+class FakeModule:
+    """Minimal pyatmo module used by async_update."""
+
+    name = "Indoor sensor"
+    room_id = None
+
+
+class FakeHome:
+    """Minimal pyatmo home used by async_update."""
+
+    entity_id = "home1"
+    name = "Test home"
+
+    def __init__(self):
+        self.modules = {"sensor1": FakeModule()}
+        self.rooms = {}
+
+    async def update(self, raw_data, do_raise_for_reachability_error=False):
+        return None
+
+
+class FakeAccount:
+    """Minimal pyatmo account used by async_update."""
+
+    user = "test@example.com"
+
+    def __init__(self):
+        self.homes = {"home1": FakeHome()}
+
+
+def _client_for_update(configs):
+    client = object.__new__(VeluxActiveClient)
+    client._account = FakeAccount()
+    client._controlled_openers_by_home = {}
+    client.async_get_raw_homestatus = AsyncMock(
+        return_value={
+            "status": "ok",
+            "body": {
+                "home": {
+                    "id": "home1",
+                    "modules": [{"id": "sensor1", "type": "NXS"}],
+                }
+            },
+        }
+    )
+    client.async_get_configs = AsyncMock(return_value=configs)
+    return client
+
+
+def test_extract_controlled_openers_uses_module_level_config():
+    raw = {
+        "status": "ok",
+        "body": {
+            "home": {
+                "modules": [
+                    {"id": "gateway1", "algo_enabled": True},
+                    {
+                        "id": "sensor1",
+                        "bridge": "gateway1",
+                        "controlled_openers": "windows",
+                    },
+                ],
+                "rooms": [{"id": "room1", "algo_enable_temperature": True}],
+            }
+        },
+    }
+
+    assert _extract_controlled_openers("home1", raw) == {
+        "sensor1": {
+            "home_id": "home1",
+            "bridge": "gateway1",
+            "controlled_openers": "windows",
+        }
+    }
+
+
+async def test_async_update_fetches_configs_for_nxs_home():
+    configs = {
+        "status": "ok",
+        "body": {
+            "home": {
+                "modules": [
+                    {
+                        "id": "sensor1",
+                        "bridge": "gateway1",
+                        "controlled_openers": "windows",
+                    }
+                ]
+            }
+        },
+    }
+    client = _client_for_update(configs)
+
+    data = await client.async_update()
+
+    client.async_get_configs.assert_awaited_once_with("home1")
+    assert data.controlled_openers == {
+        "sensor1": {
+            "home_id": "home1",
+            "bridge": "gateway1",
+            "controlled_openers": "windows",
+        }
+    }
+
+
+async def test_async_update_keeps_cached_config_when_getconfigs_fails():
+    client = _client_for_update({})
+    client._controlled_openers_by_home = {
+        "home1": {
+            "sensor1": {
+                "home_id": "home1",
+                "bridge": "gateway1",
+                "controlled_openers": "windows",
+            }
+        }
+    }
+    client.async_get_configs.side_effect = VeluxActiveCannotConnect("temporary")
+
+    data = await client.async_update()
+
+    assert data.controlled_openers["sensor1"]["controlled_openers"] == "windows"
+
+
+async def test_get_configs_uses_home_query_and_bearer_token():
+    client, session = _client_with_response({"status": "ok", "body": {}})
+
+    await client.async_get_configs("home1")
+
+    method, url, request = session.requests[0]
+    assert method == "GET"
+    assert url == "https://app.velux-active.com/syncapi/v1/getconfigs"
+    assert request["params"] == {"home_id": "home1"}
+    assert request["headers"] == {"Authorization": "Bearer access-token"}
+    assert request["timeout"].total == 10.0
+
+
+async def test_set_controlled_openers_sends_confirmed_payload_and_updates_cache():
+    client, session = _client_with_response({"status": "ok", "time_server": 1})
+
+    await client.async_set_controlled_openers(
+        "home1", "sensor1", "gateway1", "external_covers"
+    )
+
+    method, url, request = session.requests[0]
+    assert method == "POST"
+    assert url == "https://app.velux-active.com/syncapi/v1/setconfigs"
+    assert request["json"] == {
+        "home_id": "home1",
+        "home": {
+            "modules": [
+                {
+                    "id": "sensor1",
+                    "bridge": "gateway1",
+                    "controlled_openers": "external_covers",
+                }
+            ]
+        },
+    }
+    assert request["headers"] == {
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+    }
+    assert client._controlled_openers_by_home["home1"]["sensor1"] == {
+        "home_id": "home1",
+        "bridge": "gateway1",
+        "controlled_openers": "external_covers",
+    }
+
+
+async def test_set_controlled_openers_rejects_product_level_error():
+    client, _ = _client_with_response(
+        {"status": "error", "body": {"errors": [{"code": 9}]}}
+    )
+
+    with pytest.raises(VeluxActiveCannotConnect):
+        await client.async_set_controlled_openers(
+            "home1", "sensor1", "gateway1", "windows"
+        )

--- a/tests/test_api_gateway_connectivity.py
+++ b/tests/test_api_gateway_connectivity.py
@@ -38,6 +38,7 @@ class FakeAccount:
 def _client_returning(status):
     client = object.__new__(VeluxActiveClient)
     client._account = FakeAccount()
+    client._controlled_openers_by_home = {}
 
     async def async_get_raw_homestatus(home_id):
         assert home_id == "home1"

--- a/tests/test_client_get_configs.py
+++ b/tests/test_client_get_configs.py
@@ -120,9 +120,7 @@ async def test_set_sync_controlled_openers_uses_confirmed_payload():
 
 
 async def test_set_sync_controlled_openers_rejects_product_error():
-    session = FakeSession(
-        {"status": "error", "body": {"errors": [{"code": 9}]}}
-    )
+    session = FakeSession({"status": "error", "body": {"errors": [{"code": 9}]}})
     auth = SimpleNamespace(
         websession=session,
         async_get_access_token=AsyncMock(return_value="access-token"),
@@ -169,9 +167,11 @@ def test_resolve_controlled_openers_target_uses_nxs_module():
         }
     }
 
-    assert client.resolve_controlled_openers_target(
-        homesdata, "Bedroom sensor"
-    ) == ("home1", "sensor1", "gateway1")
+    assert client.resolve_controlled_openers_target(homesdata, "Bedroom sensor") == (
+        "home1",
+        "sensor1",
+        "gateway1",
+    )
 
 
 def test_parser_accepts_set_controlled_openers_command():

--- a/tests/test_client_get_configs.py
+++ b/tests/test_client_get_configs.py
@@ -1,7 +1,10 @@
-"""Tests for the client.py get-configs command."""
+"""Tests for the client.py sync configuration commands."""
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+
+import pytest
 
 import client
 
@@ -9,8 +12,10 @@ import client
 class FakeResponse:
     """Minimal aiohttp response context manager."""
 
-    status = 200
-    ok = True
+    def __init__(self, payload, *, status=200):
+        self.payload = payload
+        self.status = status
+        self.ok = status < 400
 
     async def __aenter__(self):
         return self
@@ -19,18 +24,26 @@ class FakeResponse:
         return None
 
     async def text(self):
-        return '{"body":{"home":{"id":"home1","modules":[]}}}'
+        return json.dumps(self.payload)
 
 
 class FakeSession:
-    """Capture the getconfigs request."""
+    """Capture sync API requests."""
 
-    def __init__(self):
-        self.request = None
+    def __init__(self, payload=None):
+        self.payload = payload or {
+            "status": "ok",
+            "body": {"home": {"id": "home1", "modules": []}},
+        }
+        self.requests = []
 
     def get(self, url, **kwargs):
-        self.request = (url, kwargs)
-        return FakeResponse()
+        self.requests.append(("GET", url, kwargs))
+        return FakeResponse(self.payload)
+
+    def post(self, url, **kwargs):
+        self.requests.append(("POST", url, kwargs))
+        return FakeResponse(self.payload)
 
 
 async def test_get_sync_configs_uses_bearer_token_and_home_id():
@@ -47,7 +60,8 @@ async def test_get_sync_configs_uses_bearer_token_and_home_id():
     result = await client.get_sync_configs(auth, args, home_id="home1")
 
     assert result["body"]["home"]["id"] == "home1"
-    url, request = session.request
+    method, url, request = session.requests[0]
+    assert method == "GET"
     assert url == "https://app.velux-active.com/syncapi/v1/getconfigs"
     assert request["params"] == {"home_id": "home1"}
     assert request["headers"] == {"Authorization": "Bearer access-token"}
@@ -62,3 +76,115 @@ def test_parser_accepts_get_configs_command():
     assert args.command == "get-configs"
     assert args.home == "home1"
     assert args.access_token == "access-token"
+
+
+async def test_set_sync_controlled_openers_uses_confirmed_payload():
+    session = FakeSession()
+    auth = SimpleNamespace(
+        websession=session,
+        async_get_access_token=AsyncMock(return_value="access-token"),
+    )
+    args = SimpleNamespace(
+        sync_base_url="https://app.velux-active.com/",
+        timeout=10.0,
+    )
+
+    await client.set_sync_controlled_openers(
+        auth,
+        args,
+        home_id="home1",
+        module_id="sensor1",
+        bridge_id="gateway1",
+        controlled_openers="external_covers",
+    )
+
+    method, url, request = session.requests[0]
+    assert method == "POST"
+    assert url == "https://app.velux-active.com/syncapi/v1/setconfigs"
+    assert request["json"] == {
+        "home_id": "home1",
+        "home": {
+            "modules": [
+                {
+                    "id": "sensor1",
+                    "bridge": "gateway1",
+                    "controlled_openers": "external_covers",
+                }
+            ]
+        },
+    }
+    assert request["headers"] == {
+        "Authorization": "Bearer access-token",
+        "Content-Type": "application/json",
+    }
+
+
+async def test_set_sync_controlled_openers_rejects_product_error():
+    session = FakeSession(
+        {"status": "error", "body": {"errors": [{"code": 9}]}}
+    )
+    auth = SimpleNamespace(
+        websession=session,
+        async_get_access_token=AsyncMock(return_value="access-token"),
+    )
+    args = SimpleNamespace(
+        sync_base_url="https://app.velux-active.com/",
+        timeout=10.0,
+    )
+
+    with pytest.raises(RuntimeError, match="setconfigs failed"):
+        await client.set_sync_controlled_openers(
+            auth,
+            args,
+            home_id="home1",
+            module_id="sensor1",
+            bridge_id="gateway1",
+            controlled_openers="windows",
+        )
+
+
+def test_resolve_controlled_openers_target_uses_nxs_module():
+    homesdata = {
+        "body": {
+            "homes": [
+                {
+                    "id": "home1",
+                    "name": "Home",
+                    "modules": [
+                        {
+                            "id": "sensor1",
+                            "name": "Bedroom sensor",
+                            "type": "NXS",
+                            "bridge": "gateway1",
+                        },
+                        {
+                            "id": "switch1",
+                            "name": "Departure switch",
+                            "type": "NXD",
+                            "bridge": "gateway1",
+                        },
+                    ],
+                }
+            ]
+        }
+    }
+
+    assert client.resolve_controlled_openers_target(
+        homesdata, "Bedroom sensor"
+    ) == ("home1", "sensor1", "gateway1")
+
+
+def test_parser_accepts_set_controlled_openers_command():
+    args = client.build_parser().parse_args(
+        [
+            "set-controlled-openers",
+            "sensor1",
+            "external_covers",
+            "--access-token",
+            "access-token",
+        ]
+    )
+
+    assert args.command == "set-controlled-openers"
+    assert args.module == "sensor1"
+    assert args.controlled_openers == "external_covers"

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,103 @@
+"""Tests for VELUX indoor climate sensor controlled-product selects."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from homeassistant.const import EntityCategory
+from velux_active import select
+
+
+class FakeData:
+    def __init__(self):
+        self.sensor_modules = {
+            "sensor1": {
+                "id": "sensor1",
+                "type": "NXS",
+                "name": "Indoor sensor",
+                "room_name": "Bedroom",
+            },
+            "switch1": {"id": "switch1", "type": "NXD"},
+        }
+        self.controlled_openers = {
+            "sensor1": {
+                "home_id": "home1",
+                "bridge": "gateway1",
+                "controlled_openers": "windows",
+            },
+            "switch1": {
+                "home_id": "home1",
+                "bridge": "gateway1",
+                "controlled_openers": "windows",
+            },
+        }
+
+
+class FakeCoordinator:
+    def __init__(self):
+        self.data = FakeData()
+        self.client = SimpleNamespace(async_set_controlled_openers=AsyncMock())
+        self.async_request_refresh = AsyncMock()
+        self.listeners = []
+
+    def async_add_listener(self, listener):
+        self.listeners.append(listener)
+        return lambda: self.listeners.remove(listener)
+
+
+class FakeEntry:
+    def __init__(self):
+        self.runtime_data = FakeCoordinator()
+
+    def async_on_unload(self, remove_listener):
+        return None
+
+
+async def test_setup_adds_select_only_for_nxs_modules():
+    entities = []
+
+    await select.async_setup_entry(None, FakeEntry(), entities.extend)
+
+    assert [entity._attr_unique_id for entity in entities] == [
+        "sensor1_controlled_openers"
+    ]
+    assert entities[0]._attr_options == ["windows", "external_covers"]
+    assert entities[0]._attr_entity_category == EntityCategory.CONFIG
+
+
+async def test_select_uses_reported_state_and_writes_confirmed_payload():
+    coordinator = FakeCoordinator()
+    entity = select.VeluxControlledOpenersSelect(coordinator, "sensor1")
+    entity.async_write_ha_state = Mock()
+
+    assert entity.current_option == "windows"
+    assert entity.available
+
+    await entity.async_select_option("external_covers")
+
+    coordinator.client.async_set_controlled_openers.assert_awaited_once_with(
+        "home1", "sensor1", "gateway1", "external_covers"
+    )
+    assert entity.current_option == "external_covers"
+    entity.async_write_ha_state.assert_called_once_with()
+    coordinator.async_request_refresh.assert_awaited_once_with()
+
+
+async def test_select_is_discovered_once_when_config_appears():
+    entities = []
+    entry = FakeEntry()
+    entry.runtime_data.data.controlled_openers = {}
+
+    await select.async_setup_entry(None, entry, entities.extend)
+    assert entities == []
+
+    entry.runtime_data.data.controlled_openers["sensor1"] = {
+        "home_id": "home1",
+        "bridge": "gateway1",
+        "controlled_openers": "windows",
+    }
+    entry.runtime_data.listeners[0]()
+    entry.runtime_data.listeners[0]()
+
+    assert [entity._attr_unique_id for entity in entities] == [
+        "sensor1_controlled_openers"
+    ]


### PR DESCRIPTION
## Summary

- add a per-NXS **Controlled products** select in Home Assistant with the confirmed `windows` and `external_covers` options
- read the current value from `GET /syncapi/v1/getconfigs` and write changes through `POST /syncapi/v1/setconfigs`
- preserve the last known setting when the optional config request fails, without affecting normal cover polling
- add `client.py set-controlled-openers <module> <mode>` for standalone debugging and testing
- reject HTTP-success responses that contain product-level API errors

## User impact

Users with VELUX NXS indoor climate sensors can choose whether each sensor controls windows or exterior covers directly from its physical Home Assistant device. The standalone client exposes the same write operation for diagnostics.

## Validation

- `uv run pytest -q` — 62 passed
- `uv run --with ruff ruff check client.py custom_components/velux_active tests`
- `git diff --check`

Closes #30