### PR TITLE
Add realtime WebSocket cover updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Home Assistant custom integration for VELUX ACTIVE with NETATMO, supporting:
 - **Automatic ventilation** - enable or disable the gateway algorithm for roof windows. Works without signing keys.
 - **Departure mode** - lock/unlock all movement via the gateway (e.g. for alarm integrations). Locking works without keys; unlocking requires signing.
 - **Room climate sensors** - temperature, CO2, humidity, illuminance, air quality, plus NXS/NXD battery and RF diagnostics.
+- **Realtime cover state** - receive cover movement and position updates from the VELUX cloud event stream.
 
 ---
 
@@ -94,6 +95,13 @@ entity registry if useful.
 
 Signed roof-window commands always include the VELUX rain override so they do not depend on the reported-rain state being current. During rain, VELUX limits openings to 50% and closes them after at most 15 minutes.
 
+### Realtime Updates
+
+The integration subscribes to the VELUX cloud event stream and applies cover
+movement and position updates as they arrive. Normal 30-second REST polling is
+kept as a fallback for missed events and for gateway, climate, and diagnostic
+data that is not included in cover events.
+
 ---
 
 ## Departure Mode
@@ -166,6 +174,7 @@ Examples:
 ./client.py login you@example.com 'your-password'
 ./client.py list-devices --email you@example.com --password 'your-password'
 ./client.py raw-homesdata --email you@example.com --password 'your-password'
+./client.py watch-events --email you@example.com --password 'your-password'
 ./client.py set-cover-position <device_id> 50 --email you@example.com --password 'your-password'
 ```
 

--- a/client.py
+++ b/client.py
@@ -45,6 +45,7 @@ from pyatmo.enums import ScheduleType
 from pyatmo.exceptions import NoDeviceError
 from pyatmo.helpers import extract_raw_data
 from pyatmo.modules.device_types import DeviceType
+from realtime import async_iter_events
 from signing import (
     allocate_nonces,
     build_signed_modules,
@@ -499,6 +500,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print raw /homesdata response",
     )
 
+    subparsers.add_parser(
+        "watch-events",
+        parents=[auth_parent],
+        help="Stream realtime VELUX events as JSON lines",
+    )
+
     raw_status_parser = subparsers.add_parser(
         "raw-homestatus",
         parents=[auth_parent],
@@ -647,6 +654,18 @@ async def command_raw_homesdata(args: argparse.Namespace) -> dict[str, Any]:
     async with aiohttp.ClientSession() as websession:
         auth = build_auth(args, websession)
         return await post_api_json(auth, GETHOMESDATA_ENDPOINT)
+
+
+async def command_watch_events(args: argparse.Namespace) -> None:
+    """Stream realtime WebSocket events until interrupted."""
+    async with aiohttp.ClientSession() as websession:
+        auth = build_auth(args, websession)
+        async for event in async_iter_events(
+            websession,
+            auth.async_get_access_token,
+            args.app_version,
+        ):
+            print_json_line(event)
 
 
 async def command_raw_homestatus(args: argparse.Namespace) -> dict[str, Any]:
@@ -1625,7 +1644,14 @@ def print_json(payload: dict[str, Any], *, stream: Any = sys.stdout) -> None:
     stream.write("\n")
 
 
-async def run(args: argparse.Namespace) -> dict[str, Any]:
+def print_json_line(payload: dict[str, Any], *, stream: Any = sys.stdout) -> None:
+    """Print one compact JSON line and flush it immediately."""
+    json.dump(payload, stream, separators=(",", ":"))
+    stream.write("\n")
+    stream.flush()
+
+
+async def run(args: argparse.Namespace) -> dict[str, Any] | None:
     """Run the requested command."""
 
     if args.command == "login":
@@ -1634,6 +1660,8 @@ async def run(args: argparse.Namespace) -> dict[str, Any]:
         return await command_list_devices(args)
     if args.command == "raw-homesdata":
         return await command_raw_homesdata(args)
+    if args.command == "watch-events":
+        return await command_watch_events(args)
     if args.command == "raw-homestatus":
         return await command_raw_homestatus(args)
     if args.command == "get-configs":
@@ -1663,6 +1691,8 @@ def main() -> int:
     try:
         result = asyncio.run(run(args))
     except KeyboardInterrupt:
+        if args.command == "watch-events":
+            return 0
         print_json(
             {
                 "ok": False,
@@ -1681,7 +1711,8 @@ def main() -> int:
         )
         return 1
 
-    print_json({"ok": True, "result": result})
+    if result is not None:
+        print_json({"ok": True, "result": result})
     return 0
 
 

--- a/custom_components/velux_active/__init__.py
+++ b/custom_components/velux_active/__init__.py
@@ -56,6 +56,7 @@ async def async_setup_entry(
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    coordinator.start_realtime()
 
     async def _async_update_listener(
         hass: HomeAssistant,
@@ -87,4 +88,7 @@ async def async_unload_entry(
     entry: VeluxActiveConfigEntry,
 ) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        await entry.runtime_data.async_stop_realtime()
+    return unload_ok

--- a/custom_components/velux_active/api.py
+++ b/custom_components/velux_active/api.py
@@ -45,7 +45,6 @@ ScheduleType._value2member_map_.setdefault("algo", ScheduleType.AUTO)
 
 DEFAULT_CLIENT_ID = "5931426da127d981e76bdd3f"
 DEFAULT_CLIENT_SECRET = "6ae2d89d15e767ae5c56b456b452d319"
-DEFAULT_APP_VERSION = "791302006"
 DEFAULT_SCOPE = "velux_scopes"
 DEFAULT_TIMEOUT = 10.0
 DEFAULT_USER_PREFIX = "velux"
@@ -215,7 +214,7 @@ class VeluxActiveAuth(AbstractAsyncAuth):
         data = {
             "client_id": DEFAULT_CLIENT_ID,
             "client_secret": DEFAULT_CLIENT_SECRET,
-            "app_version": DEFAULT_APP_VERSION,
+            "app_version": VELUX_APP_VERSION,
             **payload,
         }
 
@@ -319,14 +318,13 @@ class VeluxActiveClient:
         await self.async_setup()  # Load topology first
         await self.async_update()
 
-    async def async_realtime_events(self) -> AsyncIterator[dict[str, Any]]:
+    def async_realtime_events(self) -> AsyncIterator[dict[str, Any]]:
         """Yield embedded events from the VELUX app WebSocket."""
-        async for event in async_iter_events(
+        return async_iter_events(
             self._auth.websession,
             self._auth.async_get_access_token,
             VELUX_APP_VERSION,
-        ):
-            yield event
+        )
 
     def apply_realtime_cover_event(self, event: Mapping[str, Any]) -> bool:
         """Apply one partial WebSocket event to known cover objects."""

--- a/custom_components/velux_active/api.py
+++ b/custom_components/velux_active/api.py
@@ -312,6 +312,7 @@ class VeluxActiveClient:
         )
         self._account = AsyncAccount(self._auth)
         self._controlled_openers_by_home: dict[str, dict[str, dict[str, str]]] = {}
+        self._realtime_timestamps: dict[tuple[str, str], int] = {}
 
     async def async_validate(self) -> None:
         """Validate credentials by loading account topology and status."""
@@ -332,7 +333,8 @@ class VeluxActiveClient:
         if not isinstance(raw_home, Mapping):
             return False
 
-        home = self._account.homes.get(str(raw_home.get("id") or ""))
+        home_id = str(raw_home.get("id") or "")
+        home = self._account.homes.get(home_id)
         if home is None:
             return False
 
@@ -346,13 +348,25 @@ class VeluxActiveClient:
             if not isinstance(raw_module, Mapping):
                 continue
 
-            module = home.modules.get(str(raw_module.get("id") or ""))
+            module_id = str(raw_module.get("id") or "")
+            module = home.modules.get(module_id)
             if module is None or not _is_cover_module(module):
                 continue
 
             last_seen = _optional_int(raw_module.get("last_seen"))
             incoming_timestamp = last_seen if last_seen is not None else event_timestamp
-            current_timestamp = _optional_int(getattr(module, "last_seen", None))
+            timestamp_key = (home_id, module_id)
+            current_timestamp = max(
+                (
+                    timestamp
+                    for timestamp in (
+                        _optional_int(getattr(module, "last_seen", None)),
+                        self._realtime_timestamps.get(timestamp_key),
+                    )
+                    if timestamp is not None
+                ),
+                default=None,
+            )
             if (
                 incoming_timestamp is not None
                 and current_timestamp is not None
@@ -360,13 +374,17 @@ class VeluxActiveClient:
             ):
                 continue
 
+            has_realtime_state = False
             for field in REALTIME_COVER_FIELDS:
                 if field not in raw_module:
                     continue
+                has_realtime_state = True
                 value = raw_module[field]
                 if getattr(module, field, None) != value:
                     setattr(module, field, value)
                     changed = True
+            if has_realtime_state and incoming_timestamp is not None:
+                self._realtime_timestamps[timestamp_key] = incoming_timestamp
 
         return changed
 

--- a/custom_components/velux_active/api.py
+++ b/custom_components/velux_active/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping
 from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import Any
@@ -35,7 +35,9 @@ from .const import (
     LOGGER,
     SETCONFIGS_ENDPOINT,
     VELUX_API_URL,
+    VELUX_APP_VERSION,
 )
+from .realtime import async_iter_events
 from .signing import retrieve_key_error
 
 # Work around pyatmo 9.4.0 until https://github.com/jabesq-org/pyatmo/pull/564 is released.
@@ -105,6 +107,13 @@ class VeluxActiveData:
 BATTERY_MODULE_TYPES = frozenset({"NXS", "NXD"})
 ROOM_MEASUREMENT_KEYS = frozenset(
     {"temperature", "co2", "humidity", "lux", "air_quality"}
+)
+REALTIME_COVER_FIELDS = (
+    "current_position",
+    "target_position",
+    "reachable",
+    "mode",
+    "last_seen",
 )
 
 
@@ -277,6 +286,14 @@ def _is_cover_module(module: Any) -> bool:
     )
 
 
+def _optional_int(value: Any) -> int | None:
+    """Return an integer value when possible."""
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
 class VeluxActiveClient:
     def __init__(
         self,
@@ -301,6 +318,59 @@ class VeluxActiveClient:
         """Validate credentials by loading account topology and status."""
         await self.async_setup()  # Load topology first
         await self.async_update()
+
+    async def async_realtime_events(self) -> AsyncIterator[dict[str, Any]]:
+        """Yield embedded events from the VELUX app WebSocket."""
+        async for event in async_iter_events(
+            self._auth.websession,
+            self._auth.async_get_access_token,
+            VELUX_APP_VERSION,
+        ):
+            yield event
+
+    def apply_realtime_cover_event(self, event: Mapping[str, Any]) -> bool:
+        """Apply one partial WebSocket event to known cover objects."""
+        raw_home = event.get("home")
+        if not isinstance(raw_home, Mapping):
+            return False
+
+        home = self._account.homes.get(str(raw_home.get("id") or ""))
+        if home is None:
+            return False
+
+        raw_modules = raw_home.get("modules")
+        if not isinstance(raw_modules, list):
+            return False
+
+        event_timestamp = _optional_int(event.get("timestamp"))
+        changed = False
+        for raw_module in raw_modules:
+            if not isinstance(raw_module, Mapping):
+                continue
+
+            module = home.modules.get(str(raw_module.get("id") or ""))
+            if module is None or not _is_cover_module(module):
+                continue
+
+            last_seen = _optional_int(raw_module.get("last_seen"))
+            incoming_timestamp = last_seen if last_seen is not None else event_timestamp
+            current_timestamp = _optional_int(getattr(module, "last_seen", None))
+            if (
+                incoming_timestamp is not None
+                and current_timestamp is not None
+                and incoming_timestamp < current_timestamp
+            ):
+                continue
+
+            for field in REALTIME_COVER_FIELDS:
+                if field not in raw_module:
+                    continue
+                value = raw_module[field]
+                if getattr(module, field, None) != value:
+                    setattr(module, field, value)
+                    changed = True
+
+        return changed
 
     async def async_get_raw_homesdata(self) -> dict[str, Any]:
         """Return raw homesdata from the Velux API."""

--- a/custom_components/velux_active/coordinator.py
+++ b/custom_components/velux_active/coordinator.py
@@ -19,6 +19,7 @@ from .api import (
     VeluxActiveInvalidAuth,
 )
 from .const import DOMAIN, LOGGER, UPDATE_INTERVAL
+from .realtime import MAX_RECONNECT_DELAY, RECONNECT_DELAY
 
 type VeluxActiveConfigEntry = ConfigEntry[VeluxActiveDataUpdateCoordinator]
 
@@ -78,9 +79,24 @@ class VeluxActiveDataUpdateCoordinator(DataUpdateCoordinator[VeluxActiveData]):
 
     async def _async_listen_realtime(self) -> None:
         """Merge realtime cover events into the current coordinator data."""
-        async for event in self.client.async_realtime_events():
-            if self.client.apply_realtime_cover_event(event):
-                self.async_set_updated_data(self.data)
+        reconnect_delay = RECONNECT_DELAY
+        while True:
+            try:
+                async for event in self.client.async_realtime_events():
+                    reconnect_delay = RECONNECT_DELAY
+                    if self.client.apply_realtime_cover_event(event):
+                        self.async_update_listeners()
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:
+                LOGGER.warning(
+                    "VELUX WebSocket listener stopped; restarting in %.0f seconds: %s",
+                    reconnect_delay,
+                    str(err) or type(err).__name__,
+                )
+
+            await asyncio.sleep(reconnect_delay)
+            reconnect_delay = min(reconnect_delay * 2, MAX_RECONNECT_DELAY)
 
     def start_fast_polling(self) -> None:
         """Switch to fast polling for FAST_POLL_DURATION seconds after a movement."""

--- a/custom_components/velux_active/coordinator.py
+++ b/custom_components/velux_active/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
@@ -51,8 +52,35 @@ class VeluxActiveDataUpdateCoordinator(DataUpdateCoordinator[VeluxActiveData]):
         )
         self.client = client
         self._fast_poll_task: asyncio.Task | None = None
+        self._realtime_task: asyncio.Task[None] | None = None
         self._topology_loaded: bool = False
         self._consecutive_failures: int = 0
+
+    def start_realtime(self) -> None:
+        """Start listening for realtime cover updates."""
+        if self._realtime_task is not None and not self._realtime_task.done():
+            return
+        self._realtime_task = self.config_entry.async_create_background_task(
+            self.hass,
+            self._async_listen_realtime(),
+            f"{DOMAIN} websocket",
+        )
+
+    async def async_stop_realtime(self) -> None:
+        """Stop the realtime listener."""
+        task = self._realtime_task
+        self._realtime_task = None
+        if task is None or task.done():
+            return
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    async def _async_listen_realtime(self) -> None:
+        """Merge realtime cover events into the current coordinator data."""
+        async for event in self.client.async_realtime_events():
+            if self.client.apply_realtime_cover_event(event):
+                self.async_set_updated_data(self.data)
 
     def start_fast_polling(self) -> None:
         """Switch to fast polling for FAST_POLL_DURATION seconds after a movement."""

--- a/custom_components/velux_active/manifest.json
+++ b/custom_components/velux_active/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://github.com/Niek/ha-velux-active",
   "integration_type": "hub",
-  "iot_class": "cloud_polling",
+  "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/Niek/ha-velux-active/issues",
   "loggers": [
     "pyatmo"

--- a/custom_components/velux_active/manifest.json
+++ b/custom_components/velux_active/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "documentation": "https://github.com/Niek/ha-velux-active",
   "integration_type": "hub",
-  "iot_class": "cloud_push",
+  "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Niek/ha-velux-active/issues",
   "loggers": [
     "pyatmo"

--- a/custom_components/velux_active/realtime.py
+++ b/custom_components/velux_active/realtime.py
@@ -13,6 +13,7 @@ import aiohttp
 WEBSOCKET_URL = "wss://app.velux-active.com/ws/"
 WEBSOCKET_HEARTBEAT = 30.0
 RECONNECT_DELAY = 5.0
+MAX_RECONNECT_DELAY = 300.0
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,9 +54,10 @@ async def async_iter_events(
     app_version: str,
 ) -> AsyncIterator[dict[str, Any]]:
     """Yield VELUX embedded events, reconnecting after a connection ends."""
+    reconnect_delay = RECONNECT_DELAY
     while True:
-        access_token = await access_token_getter()
         try:
+            access_token = await access_token_getter()
             async with websession.ws_connect(
                 WEBSOCKET_URL,
                 heartbeat=WEBSOCKET_HEARTBEAT,
@@ -80,15 +82,20 @@ async def async_iter_events(
                         continue
 
                     status = raw.get("status")
+                    if status == "ok":
+                        reconnect_delay = RECONNECT_DELAY
                     if status is not None and status != "ok":
                         raise RuntimeError(f"WebSocket subscription failed: {status}")
 
                     if event := extract_embedded_event(raw):
+                        reconnect_delay = RECONNECT_DELAY
                         yield event
         except (aiohttp.ClientError, OSError, TimeoutError) as err:
             _LOGGER.debug(
-                "VELUX WebSocket disconnected; reconnecting: %s",
-                err or type(err).__name__,
+                "VELUX WebSocket disconnected; reconnecting in %.0f seconds: %s",
+                reconnect_delay,
+                str(err) or type(err).__name__,
             )
 
-        await asyncio.sleep(RECONNECT_DELAY)
+        await asyncio.sleep(reconnect_delay)
+        reconnect_delay = min(reconnect_delay * 2, MAX_RECONNECT_DELAY)

--- a/custom_components/velux_active/realtime.py
+++ b/custom_components/velux_active/realtime.py
@@ -1,0 +1,98 @@
+"""VELUX app WebSocket event stream."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from typing import Any
+
+import aiohttp
+
+WEBSOCKET_URL = "wss://app.velux-active.com/ws/"
+WEBSOCKET_HEARTBEAT = 30.0
+RECONNECT_DELAY = 5.0
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def build_subscribe_message(
+    access_token: str,
+    app_version: str,
+) -> dict[str, str]:
+    """Build the subscription message used by the VELUX Android app."""
+    return {
+        "action": "Subscribe",
+        "filter": "silent",
+        "access_token": access_token,
+        "app_type": "app_velux",
+        "platform": "Android",
+        "version": app_version,
+    }
+
+
+def extract_embedded_event(message: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Extract an embedded JSON event from one WebSocket message."""
+    if message.get("push_type") != "embedded_json":
+        return None
+
+    extra_params = message.get("extra_params")
+    if isinstance(extra_params, str):
+        try:
+            extra_params = json.loads(extra_params)
+        except json.JSONDecodeError:
+            return None
+
+    return dict(extra_params) if isinstance(extra_params, Mapping) else None
+
+
+async def async_iter_events(
+    websession: aiohttp.ClientSession,
+    access_token_getter: Callable[[], Awaitable[str]],
+    app_version: str,
+) -> AsyncIterator[dict[str, Any]]:
+    """Yield VELUX embedded events, reconnecting after a connection ends."""
+    while True:
+        try:
+            access_token = await access_token_getter()
+            async with websession.ws_connect(
+                WEBSOCKET_URL,
+                heartbeat=WEBSOCKET_HEARTBEAT,
+            ) as websocket:
+                await websocket.send_json(
+                    build_subscribe_message(access_token, app_version)
+                )
+
+                async for message in websocket:
+                    if message.type is aiohttp.WSMsgType.ERROR:
+                        raise aiohttp.ClientConnectionError(
+                            str(websocket.exception() or "WebSocket connection failed")
+                        )
+                    if message.type is not aiohttp.WSMsgType.TEXT:
+                        continue
+
+                    try:
+                        raw: Any = json.loads(message.data)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    if not isinstance(raw, Mapping):
+                        continue
+
+                    status = raw.get("status")
+                    if status is not None and status != "ok":
+                        raise aiohttp.ClientConnectionError(
+                            f"WebSocket subscription failed: {status}"
+                        )
+
+                    if event := extract_embedded_event(raw):
+                        yield event
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:
+            _LOGGER.debug(
+                "VELUX WebSocket disconnected; reconnecting: %s",
+                err or type(err).__name__,
+            )
+
+        await asyncio.sleep(RECONNECT_DELAY)

--- a/custom_components/velux_active/realtime.py
+++ b/custom_components/velux_active/realtime.py
@@ -54,8 +54,8 @@ async def async_iter_events(
 ) -> AsyncIterator[dict[str, Any]]:
     """Yield VELUX embedded events, reconnecting after a connection ends."""
     while True:
+        access_token = await access_token_getter()
         try:
-            access_token = await access_token_getter()
             async with websession.ws_connect(
                 WEBSOCKET_URL,
                 heartbeat=WEBSOCKET_HEARTBEAT,
@@ -81,15 +81,11 @@ async def async_iter_events(
 
                     status = raw.get("status")
                     if status is not None and status != "ok":
-                        raise aiohttp.ClientConnectionError(
-                            f"WebSocket subscription failed: {status}"
-                        )
+                        raise RuntimeError(f"WebSocket subscription failed: {status}")
 
                     if event := extract_embedded_event(raw):
                         yield event
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:
+        except (aiohttp.ClientError, OSError, TimeoutError) as err:
             _LOGGER.debug(
                 "VELUX WebSocket disconnected; reconnecting: %s",
                 err or type(err).__name__,

--- a/tests/test_api_realtime.py
+++ b/tests/test_api_realtime.py
@@ -1,0 +1,107 @@
+"""Tests for realtime cover-state merging."""
+
+from types import SimpleNamespace
+
+from velux_active.api import VeluxActiveClient
+
+
+class FakeCover:
+    """Small duck-typed pyatmo cover."""
+
+    def __init__(self):
+        self.current_position = 100
+        self.target_position = 100
+        self.reachable = True
+        self.mode = "manual"
+        self.last_seen = 100
+        self.bridge = "gateway1"
+        self.velux_type = "awning_blind"
+
+    async def async_set_target_position(self, position):
+        return True
+
+
+def make_client(cover):
+    client = object.__new__(VeluxActiveClient)
+    client._account = SimpleNamespace(
+        homes={"home1": SimpleNamespace(modules={"cover1": cover})}
+    )
+    return client
+
+
+def test_realtime_event_updates_only_cover_state_fields():
+    cover = FakeCover()
+    client = make_client(cover)
+
+    changed = client.apply_realtime_cover_event(
+        {
+            "timestamp": 200,
+            "correlation_id": "correlation1",
+            "home": {
+                "id": "home1",
+                "modules": [
+                    {
+                        "id": "cover1",
+                        "current_position": 100,
+                        "target_position": 0,
+                        "reachable": True,
+                        "mode": "algo_disabled",
+                        "last_seen": 200,
+                        "bridge": "changed-gateway",
+                        "velux_type": "changed-type",
+                    }
+                ],
+            },
+        }
+    )
+
+    assert changed is True
+    assert cover.current_position == 100
+    assert cover.target_position == 0
+    assert cover.reachable is True
+    assert cover.mode == "algo_disabled"
+    assert cover.last_seen == 200
+    assert cover.bridge == "gateway1"
+    assert cover.velux_type == "awning_blind"
+
+
+def test_realtime_event_ignores_stale_cover_state():
+    cover = FakeCover()
+    client = make_client(cover)
+
+    changed = client.apply_realtime_cover_event(
+        {
+            "timestamp": 99,
+            "home": {
+                "id": "home1",
+                "modules": [
+                    {
+                        "id": "cover1",
+                        "current_position": 0,
+                        "target_position": 0,
+                    }
+                ],
+            },
+        }
+    )
+
+    assert changed is False
+    assert cover.current_position == 100
+    assert cover.target_position == 100
+    assert cover.last_seen == 100
+
+
+def test_realtime_event_ignores_unknown_or_malformed_payloads():
+    client = make_client(FakeCover())
+
+    assert client.apply_realtime_cover_event({}) is False
+    assert (
+        client.apply_realtime_cover_event({"home": {"id": "unknown", "modules": []}})
+        is False
+    )
+    assert (
+        client.apply_realtime_cover_event(
+            {"home": {"id": "home1", "modules": [{"id": "unknown"}]}}
+        )
+        is False
+    )

--- a/tests/test_api_realtime.py
+++ b/tests/test_api_realtime.py
@@ -26,6 +26,7 @@ def make_client(cover):
     client._account = SimpleNamespace(
         homes={"home1": SimpleNamespace(modules={"cover1": cover})}
     )
+    client._realtime_timestamps = {}
     return client
 
 
@@ -89,6 +90,52 @@ def test_realtime_event_ignores_stale_cover_state():
     assert cover.current_position == 100
     assert cover.target_position == 100
     assert cover.last_seen == 100
+
+
+def test_realtime_event_persists_fallback_timestamp():
+    cover = FakeCover()
+    client = make_client(cover)
+
+    assert (
+        client.apply_realtime_cover_event(
+            {
+                "timestamp": 200,
+                "home": {
+                    "id": "home1",
+                    "modules": [
+                        {
+                            "id": "cover1",
+                            "current_position": 50,
+                            "target_position": 0,
+                        }
+                    ],
+                },
+            }
+        )
+        is True
+    )
+    assert client._realtime_timestamps[("home1", "cover1")] == 200
+
+    assert (
+        client.apply_realtime_cover_event(
+            {
+                "timestamp": 150,
+                "home": {
+                    "id": "home1",
+                    "modules": [
+                        {
+                            "id": "cover1",
+                            "current_position": 75,
+                            "target_position": 100,
+                        }
+                    ],
+                },
+            }
+        )
+        is False
+    )
+    assert cover.current_position == 50
+    assert cover.target_position == 0
 
 
 def test_realtime_event_ignores_unknown_or_malformed_payloads():

--- a/tests/test_client_get_configs.py
+++ b/tests/test_client_get_configs.py
@@ -78,6 +78,15 @@ def test_parser_accepts_get_configs_command():
     assert args.access_token == "access-token"
 
 
+def test_parser_accepts_watch_events_command():
+    args = client.build_parser().parse_args(
+        ["watch-events", "--access-token", "access-token"]
+    )
+
+    assert args.command == "watch-events"
+    assert args.access_token == "access-token"
+
+
 async def test_set_sync_controlled_openers_uses_confirmed_payload():
     session = FakeSession()
     auth = SimpleNamespace(

--- a/tests/test_coordinator_failure_threshold.py
+++ b/tests/test_coordinator_failure_threshold.py
@@ -1,4 +1,6 @@
-"""Tests for coordinator failure-threshold behavior."""
+"""Tests for coordinator behavior."""
+
+import asyncio
 
 import pytest
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -21,3 +23,66 @@ def test_failure_threshold_marks_update_failed():
 
     with pytest.raises(UpdateFailed):
         coordinator._handle_update_error(error)
+
+
+async def test_realtime_listener_notifies_only_for_changed_events():
+    class FakeClient:
+        async def async_realtime_events(self):
+            yield {"changed": True}
+            yield {"changed": False}
+
+        def apply_realtime_cover_event(self, event):
+            return event["changed"]
+
+    coordinator = object.__new__(VeluxActiveDataUpdateCoordinator)
+    coordinator.client = FakeClient()
+    coordinator.data = data = object()
+    updates = []
+    coordinator.async_set_updated_data = updates.append
+
+    await coordinator._async_listen_realtime()
+
+    assert updates == [data]
+
+
+async def test_start_realtime_uses_config_entry_background_task():
+    class FakeConfigEntry:
+        def __init__(self):
+            self.calls = []
+
+        def async_create_background_task(self, hass, target, name):
+            self.calls.append((hass, name))
+            return asyncio.create_task(target)
+
+    coordinator = object.__new__(VeluxActiveDataUpdateCoordinator)
+    coordinator.hass = hass = object()
+    coordinator.config_entry = config_entry = FakeConfigEntry()
+    coordinator._realtime_task = None
+
+    async def listen_once():
+        return None
+
+    coordinator._async_listen_realtime = listen_once
+
+    coordinator.start_realtime()
+    await coordinator._realtime_task
+
+    assert config_entry.calls == [(hass, "velux_active websocket")]
+
+
+async def test_stop_realtime_cancels_listener_task():
+    coordinator = object.__new__(VeluxActiveDataUpdateCoordinator)
+    started = asyncio.Event()
+
+    async def wait_forever():
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(wait_forever())
+    await started.wait()
+    coordinator._realtime_task = task
+
+    await coordinator.async_stop_realtime()
+
+    assert coordinator._realtime_task is None
+    assert task.cancelled()

--- a/tests/test_coordinator_failure_threshold.py
+++ b/tests/test_coordinator_failure_threshold.py
@@ -3,6 +3,7 @@
 import asyncio
 
 import pytest
+import velux_active.coordinator as coordinator_module
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from pyatmo.exceptions import ApiError
 from velux_active.coordinator import (
@@ -26,23 +27,66 @@ def test_failure_threshold_marks_update_failed():
 
 
 async def test_realtime_listener_notifies_only_for_changed_events():
+    processed = asyncio.Event()
+
     class FakeClient:
         async def async_realtime_events(self):
             yield {"changed": True}
             yield {"changed": False}
+            await asyncio.Event().wait()
 
         def apply_realtime_cover_event(self, event):
+            if not event["changed"]:
+                processed.set()
             return event["changed"]
 
     coordinator = object.__new__(VeluxActiveDataUpdateCoordinator)
     coordinator.client = FakeClient()
-    coordinator.data = data = object()
     updates = []
-    coordinator.async_set_updated_data = updates.append
+    coordinator.last_update_success = False
+    coordinator.async_update_listeners = lambda: updates.append(True)
+    coordinator.async_set_updated_data = lambda data: pytest.fail(
+        "Realtime updates must not reset coordinator polling state"
+    )
 
-    await coordinator._async_listen_realtime()
+    task = asyncio.create_task(coordinator._async_listen_realtime())
+    await processed.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
-    assert updates == [data]
+    assert updates == [True]
+    assert coordinator.last_update_success is False
+
+
+async def test_realtime_listener_restarts_after_error(monkeypatch):
+    restarted = asyncio.Event()
+
+    class FakeClient:
+        calls = 0
+
+        async def async_realtime_events(self):
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("subscription failed")
+            restarted.set()
+            await asyncio.Event().wait()
+            yield
+
+        def apply_realtime_cover_event(self, event):
+            return False
+
+    coordinator = object.__new__(VeluxActiveDataUpdateCoordinator)
+    coordinator.client = client = FakeClient()
+    monkeypatch.setattr(coordinator_module, "RECONNECT_DELAY", 0)
+
+    task = asyncio.create_task(coordinator._async_listen_realtime())
+    await restarted.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert client.calls == 2
 
 
 async def test_start_realtime_uses_config_entry_background_task():

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,0 +1,141 @@
+"""Tests for the VELUX app WebSocket protocol."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import aiohttp
+from velux_active.realtime import (
+    WEBSOCKET_HEARTBEAT,
+    WEBSOCKET_URL,
+    async_iter_events,
+    build_subscribe_message,
+    extract_embedded_event,
+)
+
+
+class FakeWebSocket:
+    """Minimal WebSocket async iterator."""
+
+    def __init__(self, messages):
+        self.messages = iter(messages)
+        self.sent = []
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.closed = True
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self.messages)
+        except StopIteration as err:
+            raise StopAsyncIteration from err
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+    def exception(self):
+        return None
+
+
+class FakeSession:
+    """Return fake WebSocket connections in order."""
+
+    def __init__(self, *websockets):
+        self.websockets = iter(websockets)
+        self.connections = []
+
+    def ws_connect(self, url, **kwargs):
+        self.connections.append((url, kwargs))
+        return next(self.websockets)
+
+
+def test_build_subscribe_message_matches_android_app():
+    assert build_subscribe_message("token", "791302006") == {
+        "action": "Subscribe",
+        "filter": "silent",
+        "access_token": "token",
+        "app_type": "app_velux",
+        "platform": "Android",
+        "version": "791302006",
+    }
+
+
+def test_extract_embedded_event_accepts_object_and_json_string():
+    event = {"timestamp": 123, "home": {"id": "home1"}}
+
+    assert (
+        extract_embedded_event({"push_type": "embedded_json", "extra_params": event})
+        == event
+    )
+    assert (
+        extract_embedded_event(
+            {"push_type": "embedded_json", "extra_params": json.dumps(event)}
+        )
+        == event
+    )
+    assert extract_embedded_event({"status": "ok"}) is None
+    assert (
+        extract_embedded_event(
+            {"push_type": "embedded_json", "extra_params": "not-json"}
+        )
+        is None
+    )
+
+
+async def test_iter_events_subscribes_and_yields_embedded_payload():
+    event = {"timestamp": 123, "home": {"id": "home1"}}
+    websocket = FakeWebSocket(
+        [
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps({"status": "ok"}),
+            ),
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps({"push_type": "embedded_json", "extra_params": event}),
+            ),
+        ]
+    )
+    session = FakeSession(websocket)
+    get_access_token = AsyncMock(return_value="token")
+    events = async_iter_events(session, get_access_token, "791302006")
+
+    assert await anext(events) == event
+    await events.aclose()
+
+    assert session.connections == [(WEBSOCKET_URL, {"heartbeat": WEBSOCKET_HEARTBEAT})]
+    assert websocket.sent == [build_subscribe_message("token", "791302006")]
+    assert websocket.closed is True
+
+
+async def test_iter_events_reconnects_with_fresh_access_token(monkeypatch):
+    first_websocket = FakeWebSocket([])
+    event = {"timestamp": 123, "home": {"id": "home1"}}
+    second_websocket = FakeWebSocket(
+        [
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps({"push_type": "embedded_json", "extra_params": event}),
+            )
+        ]
+    )
+    session = FakeSession(first_websocket, second_websocket)
+    get_access_token = AsyncMock(side_effect=["token1", "token2"])
+    monkeypatch.setattr("velux_active.realtime.RECONNECT_DELAY", 0)
+    events = async_iter_events(session, get_access_token, "791302006")
+
+    assert await anext(events) == event
+    await events.aclose()
+
+    assert get_access_token.await_count == 2
+    assert first_websocket.sent == [build_subscribe_message("token1", "791302006")]
+    assert second_websocket.sent == [build_subscribe_message("token2", "791302006")]
+    assert first_websocket.closed is True
+    assert second_websocket.closed is True

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import aiohttp
+import pytest
 from velux_active.realtime import (
     WEBSOCKET_HEARTBEAT,
     WEBSOCKET_URL,
@@ -139,3 +140,32 @@ async def test_iter_events_reconnects_with_fresh_access_token(monkeypatch):
     assert second_websocket.sent == [build_subscribe_message("token2", "791302006")]
     assert first_websocket.closed is True
     assert second_websocket.closed is True
+
+
+async def test_iter_events_propagates_access_token_failure():
+    session = FakeSession()
+    get_access_token = AsyncMock(side_effect=RuntimeError("Authentication failed"))
+    events = async_iter_events(session, get_access_token, "791302006")
+
+    with pytest.raises(RuntimeError, match="Authentication failed"):
+        await anext(events)
+
+    assert session.connections == []
+
+
+async def test_iter_events_propagates_subscription_failure():
+    websocket = FakeWebSocket(
+        [
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps({"status": "error"}),
+            )
+        ]
+    )
+    session = FakeSession(websocket)
+    events = async_iter_events(session, AsyncMock(return_value="token"), "791302006")
+
+    with pytest.raises(RuntimeError, match="WebSocket subscription failed: error"):
+        await anext(events)
+
+    assert websocket.closed is True

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -2,11 +2,13 @@
 
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import aiohttp
 import pytest
+import velux_active.realtime as realtime
 from velux_active.realtime import (
+    RECONNECT_DELAY,
     WEBSOCKET_HEARTBEAT,
     WEBSOCKET_URL,
     async_iter_events,
@@ -54,7 +56,10 @@ class FakeSession:
 
     def ws_connect(self, url, **kwargs):
         self.connections.append((url, kwargs))
-        return next(self.websockets)
+        result = next(self.websockets)
+        if isinstance(result, BaseException):
+            raise result
+        return result
 
 
 def test_build_subscribe_message_matches_android_app():
@@ -151,6 +156,56 @@ async def test_iter_events_propagates_access_token_failure():
         await anext(events)
 
     assert session.connections == []
+
+
+async def test_iter_events_retries_transient_access_token_failure(monkeypatch):
+    event = {"timestamp": 123, "home": {"id": "home1"}}
+    websocket = FakeWebSocket(
+        [
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps({"push_type": "embedded_json", "extra_params": event}),
+            )
+        ]
+    )
+    session = FakeSession(websocket)
+    get_access_token = AsyncMock(
+        side_effect=[aiohttp.ClientConnectionError("offline"), "token"]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(realtime.asyncio, "sleep", sleep)
+    events = async_iter_events(session, get_access_token, "791302006")
+
+    assert await anext(events) == event
+    await events.aclose()
+
+    sleep.assert_awaited_once_with(RECONNECT_DELAY)
+    assert get_access_token.await_count == 2
+
+
+async def test_iter_events_backs_off_reconnects(monkeypatch):
+    event = {"timestamp": 123, "home": {"id": "home1"}}
+    websocket = FakeWebSocket(
+        [
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps({"push_type": "embedded_json", "extra_params": event}),
+            )
+        ]
+    )
+    session = FakeSession(
+        aiohttp.ClientConnectionError(),
+        aiohttp.ClientConnectionError(),
+        websocket,
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(realtime.asyncio, "sleep", sleep)
+    events = async_iter_events(session, AsyncMock(return_value="token"), "791302006")
+
+    assert await anext(events) == event
+    await events.aclose()
+
+    assert sleep.await_args_list == [call(RECONNECT_DELAY), call(RECONNECT_DELAY * 2)]
 
 
 async def test_iter_events_propagates_subscription_failure():


### PR DESCRIPTION
## Summary

- subscribe to the VELUX app WebSocket and reconnect with a fresh access token
- merge partial realtime cover state into Home Assistant without resetting independent REST polling or availability state
- preserve per-module event ordering even when partial events omit `last_seen`
- supervise listener failures and reconnect with capped exponential backoff
- keep 30-second REST polling for missed events and for gateway, climate, and diagnostic data, retaining the `cloud_polling` classification
- add `client.py watch-events` for standalone diagnostics while preserving fatal authentication and subscription errors
- add heartbeat, lifecycle, parsing, stale-event, retry, backoff, restart, and replay-order coverage

## Validation

- `pytest -q` — 79 passed
- `ruff check .`
- `ruff format --check .`
- `git diff --check`
- live Home Assistant test: an externally commanded cover entered opening/closing state immediately and reported its completed position

Related to #36