### PR TITLE
Add gateway stop button

### DIFF
--- a/custom_components/velux_active/button.py
+++ b/custom_components/velux_active/button.py
@@ -184,6 +184,14 @@ class VeluxStopAllMovementsButton(
         """Return device info for the gateway."""
         return gateway_device_info(self._gateway_id)
 
+    @property
+    def available(self) -> bool:
+        """Return True while the gateway remains in the home topology."""
+        home = self.coordinator.data.homes.get(self._home_id)
+        return (
+            super().available and home is not None and self._gateway_id in home.modules
+        )
+
     async def async_press(self) -> None:
         """Stop all movements through the gateway."""
         home = self.coordinator.data.homes[self._home_id]
@@ -195,4 +203,6 @@ class VeluxStopAllMovementsButton(
             [{"id": self._gateway_id, "stop_movements": "all"}],
             action="Stop all movements command",
         )
+        sequences = self.coordinator.gateway_stop_sequences
+        sequences[self._gateway_id] = sequences.get(self._gateway_id, 0) + 1
         await self.coordinator.async_request_refresh()

--- a/custom_components/velux_active/button.py
+++ b/custom_components/velux_active/button.py
@@ -42,6 +42,10 @@ async def async_setup_entry(
             entities.append(
                 VeluxIdentifyButton(coordinator, home_id, module_id, module_type)
             )
+            if module_type == "NXG":
+                entities.append(
+                    VeluxStopAllMovementsButton(coordinator, home_id, module_id)
+                )
             known_modules.add(module_key)
 
         if entities:
@@ -153,3 +157,42 @@ class VeluxIdentifyButton(
             [payload],
             action="Identify command",
         )
+
+
+class VeluxStopAllMovementsButton(
+    CoordinatorEntity[VeluxActiveDataUpdateCoordinator], ButtonEntity
+):
+    """Button that stops all movements through a VELUX gateway."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Stop all movements"
+
+    def __init__(
+        self,
+        coordinator: VeluxActiveDataUpdateCoordinator,
+        home_id: str,
+        gateway_id: str,
+    ) -> None:
+        """Initialize the stop-all button."""
+        super().__init__(coordinator)
+        self._home_id = home_id
+        self._gateway_id = gateway_id
+        self._attr_unique_id = f"{gateway_id}_stop_all_movements"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the gateway."""
+        return gateway_device_info(self._gateway_id)
+
+    async def async_press(self) -> None:
+        """Stop all movements through the gateway."""
+        home = self.coordinator.data.homes[self._home_id]
+        await async_post_setstate(
+            self.coordinator.hass,
+            self.coordinator.client,
+            home.entity_id,
+            str(self.coordinator.hass.config.time_zone),
+            [{"id": self._gateway_id, "stop_movements": "all"}],
+            action="Stop all movements command",
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/velux_active/coordinator.py
+++ b/custom_components/velux_active/coordinator.py
@@ -50,6 +50,7 @@ class VeluxActiveDataUpdateCoordinator(DataUpdateCoordinator[VeluxActiveData]):
             update_interval=UPDATE_INTERVAL,
         )
         self.client = client
+        self.gateway_stop_sequences: dict[str, int] = {}
         self._fast_poll_task: asyncio.Task | None = None
         self._topology_loaded: bool = False
         self._consecutive_failures: int = 0

--- a/custom_components/velux_active/cover.py
+++ b/custom_components/velux_active/cover.py
@@ -87,6 +87,7 @@ class VeluxActiveCover(VeluxActiveEntity, CoverEntity):
         super().__init__(coordinator, module_id)
         self._motion_state: str | None = None
         self._motion_target_position: int | None = None
+        self._gateway_stop_sequence = 0
         self._is_window_device: bool = _module_is_window(module_id, self.module)
 
         entry_data = coordinator.config_entry.data
@@ -263,6 +264,13 @@ class VeluxActiveCover(VeluxActiveEntity, CoverEntity):
             self._motion_target_position = None
 
     def _handle_coordinator_update(self) -> None:
+        home = self._get_home()
+        bridge_id = self._get_bridge_id(home) if home is not None else None
+        sequence = self.coordinator.gateway_stop_sequences.get(bridge_id, 0)
+        if sequence != self._gateway_stop_sequence:
+            self._motion_state = None
+            self._motion_target_position = None
+            self._gateway_stop_sequence = sequence
         self._clear_motion_state_if_settled()
         super()._handle_coordinator_update()
 

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
-from velux_active import button
+from velux_active import button, cover
 
 
 class NXG:
@@ -21,6 +21,8 @@ class FakeModule:
         self.velux_type = velux_type
         self.room_id = None
         self.firmware_revision = 1
+        self.current_position = 50
+        self.target_position = 50
 
 
 class FakeHome:
@@ -61,6 +63,8 @@ class FakeCoordinator:
         self.data = FakeData()
         self.hass = SimpleNamespace(config=SimpleNamespace(time_zone="Europe/Berlin"))
         self.client = object()
+        self.config_entry = SimpleNamespace(data={}, entry_id="entry1")
+        self.gateway_stop_sequences = {}
         self.listeners = []
 
     def async_add_listener(self, listener):
@@ -169,3 +173,37 @@ async def test_stop_all_movements_targets_gateway_and_refreshes(monkeypatch):
         action="Stop all movements command",
     )
     coordinator.async_request_refresh.assert_awaited_once_with()
+    assert coordinator.gateway_stop_sequences == {"gateway1": 1}
+
+
+def test_stop_button_is_unavailable_without_gateway():
+    coordinator = FakeCoordinator()
+    entity = button.VeluxStopAllMovementsButton(coordinator, "home1", "gateway1")
+
+    assert entity.available
+
+    del coordinator.data.homes["home1"].modules["gateway1"]
+
+    assert not entity.available
+
+
+def test_gateway_stop_clears_optimistic_cover_motion(monkeypatch):
+    coordinator = FakeCoordinator()
+    entity = cover.VeluxActiveCover(coordinator, "window1")
+    entity._motion_state = "opening"
+    entity._motion_target_position = 100
+    monkeypatch.setattr(
+        cover.VeluxActiveEntity,
+        "_handle_coordinator_update",
+        lambda self: None,
+        raising=False,
+    )
+
+    entity._handle_coordinator_update()
+    assert entity.is_opening
+
+    coordinator.gateway_stop_sequences["gateway1"] = 1
+    entity._handle_coordinator_update()
+
+    assert not entity.is_opening
+    assert entity._motion_target_position is None

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -83,6 +83,7 @@ async def test_setup_adds_identify_buttons_for_supported_modules():
 
     assert {entity._attr_unique_id for entity in entities} == {
         "gateway1_identify",
+        "gateway1_stop_all_movements",
         "sensor1_identify",
         "switch1_identify",
         "window1_identify",
@@ -98,6 +99,7 @@ async def test_sensor_identify_buttons_are_discovered_once():
 
     assert {entity._attr_unique_id for entity in entities} == {
         "gateway1_identify",
+        "gateway1_stop_all_movements",
         "window1_identify",
     }
 
@@ -147,3 +149,23 @@ async def test_identify_omits_bridge_for_gateway(monkeypatch):
         [{"id": "gateway1", "identify": True}],
         action="Identify command",
     )
+
+
+async def test_stop_all_movements_targets_gateway_and_refreshes(monkeypatch):
+    coordinator = FakeCoordinator()
+    coordinator.async_request_refresh = AsyncMock()
+    async_post_setstate = AsyncMock()
+    monkeypatch.setattr(button, "async_post_setstate", async_post_setstate)
+    entity = button.VeluxStopAllMovementsButton(coordinator, "home1", "gateway1")
+
+    await entity.async_press()
+
+    async_post_setstate.assert_awaited_once_with(
+        coordinator.hass,
+        coordinator.client,
+        "home1",
+        "Europe/Berlin",
+        [{"id": "gateway1", "stop_movements": "all"}],
+        action="Stop all movements command",
+    )
+    coordinator.async_request_refresh.assert_awaited_once_with()


### PR DESCRIPTION
## Summary

- add a **Stop all movements** button to each VELUX gateway
- send the gateway-level `stop_movements: "all"` command and refresh integration state
- cover button discovery and the REST payload with focused tests

## Validation

- `uv run --frozen --group test pytest -q` — 63 passed
- `uvx ruff@0.16.0 check .`
- `uvx ruff@0.16.0 format --check .`

Closes #39